### PR TITLE
feat: add v1 oracle request client and example

### DIFF
--- a/libs/package.json
+++ b/libs/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "ethers": "^5.7.2",
+    "graphql-request": "^5.1.0",
     "immer": "^9.0.18"
   }
 }

--- a/libs/src/oracle2/client.ts
+++ b/libs/src/oracle2/client.ts
@@ -1,0 +1,17 @@
+import type { ServiceFactories, Handlers } from "./types";
+export function Client(factories: ServiceFactories, handlers: Handlers) {
+  const services = factories.map((factory) => factory(handlers));
+  async function tick() {
+    await Promise.all(services.map((service) => service.tick()));
+  }
+  // this will be changed eventually, we will need to re-request data
+  // on an interval, but it depends on the source of data. for now this
+  // is just an example.
+  setTimeout(() => {
+    tick().catch((err) => {
+      if (err instanceof Error) {
+        handlers.errors && handlers.errors([err]);
+      }
+    });
+  }, 4000);
+}

--- a/libs/src/oracle2/index.ts
+++ b/libs/src/oracle2/index.ts
@@ -1,1 +1,3 @@
 export * from "./types";
+export * as services from "./services";
+export * from "./client";

--- a/libs/src/oracle2/services/gql/factory.ts
+++ b/libs/src/oracle2/services/gql/factory.ts
@@ -1,0 +1,40 @@
+import { Service, Handlers, ServiceFactory, OracleType } from "../../types";
+import { convertV1 } from "./utils";
+import { getRequests as getRequestsV1 } from "./oracleV1";
+
+export type GqlConfig = {
+  url: string;
+  chainId: number;
+  type: OracleType;
+};
+export type Config = GqlConfig[];
+
+export const Factory =
+  (config: Config): ServiceFactory =>
+  (handlers: Handlers): Service => {
+    async function fetchV1({ url, chainId }: Omit<GqlConfig, "type">) {
+      const requests = await getRequestsV1(url);
+      return requests.map((request) => convertV1(request, chainId));
+    }
+    async function tickRequests() {
+      const results = await Promise.all(
+        config.map((config) => {
+          if (config.type === OracleType.Optimistic) {
+            return fetchV1(config);
+          }
+          throw new Error(`Unsupported oracle type ${config.type}`);
+        })
+      );
+      return results.flat();
+    }
+    async function tick() {
+      if (handlers.requests) {
+        const result = await tickRequests();
+        handlers.requests(result);
+      }
+    }
+
+    return {
+      tick,
+    };
+  };

--- a/libs/src/oracle2/services/gql/index.ts
+++ b/libs/src/oracle2/services/gql/index.ts
@@ -1,0 +1,3 @@
+export * from "./factory";
+export * from "./oracleV1";
+export * from "./utils";

--- a/libs/src/oracle2/services/gql/oracleV1.ts
+++ b/libs/src/oracle2/services/gql/oracleV1.ts
@@ -1,0 +1,50 @@
+import request, { gql } from "graphql-request";
+
+export type OptimisticPriceRequest = {
+  id: string;
+  identifier: string;
+  ancillaryData: string;
+  time: string;
+  requester: string;
+  currency: string;
+  reward: string;
+  finalFee: string;
+  proposer: string;
+  proposedPrice: string;
+  proposalExpirationTimestamp: string;
+  disputer: string;
+  settlementPrice: string;
+  settlementPayout: string;
+  settlementRecipient: string;
+};
+export type OptimisticPriceRequests = OptimisticPriceRequest[];
+export type OptimisticPriceRequestsQuery = {
+  optimisticPriceRequests: OptimisticPriceRequests;
+};
+export const getRequests = async (
+  url: string
+): Promise<OptimisticPriceRequests> => {
+  const query = gql`
+    {
+      optimisticPriceRequests {
+        id
+        identifier
+        ancillaryData
+        time
+        requester
+        currency
+        reward
+        finalFee
+        proposer
+        proposedPrice
+        proposalExpirationTimestamp
+        disputer
+        settlementPrice
+        settlementPayout
+        settlementRecipient
+      }
+    }
+  `;
+  const result = await request<OptimisticPriceRequestsQuery>(url, query);
+  return result.optimisticPriceRequests;
+};

--- a/libs/src/oracle2/services/gql/utils.ts
+++ b/libs/src/oracle2/services/gql/utils.ts
@@ -1,0 +1,30 @@
+import { OptimisticPriceRequest } from "./oracleV1";
+import { Request, OracleType } from "../../types";
+
+export function convertV1(
+  request: OptimisticPriceRequest,
+  chainId: number
+): Request {
+  return {
+    // request key
+    requester: request.requester,
+    identifier: request.identifier,
+    timestamp: request.time,
+    ancillaryData: request.ancillaryData,
+    // meta data
+    chainId,
+    oracleType: OracleType.Optimistic,
+    id: request.id,
+    // everything else
+    proposer: request.proposer,
+    disputer: request.disputer,
+    currency: request.currency,
+    settled: Boolean(request.settlementRecipient),
+    proposedPrice: request.proposedPrice,
+    reward: request.reward,
+    finalFee: request.finalFee,
+    price: request.settlementPrice,
+    payout: request.settlementPayout,
+    expirationTime: request.proposalExpirationTimestamp,
+  };
+}

--- a/libs/src/oracle2/services/index.ts
+++ b/libs/src/oracle2/services/index.ts
@@ -1,0 +1,1 @@
+export * as gql from "./gql";

--- a/libs/src/oracle2/types.ts
+++ b/libs/src/oracle2/types.ts
@@ -11,7 +11,7 @@ export enum RequestState {
 export type RequestKey = {
   requester: string;
   identifier: string;
-  timestamp: number;
+  timestamp: string;
   ancillaryData: string;
 };
 
@@ -73,13 +73,11 @@ export type Handlers = {
   // errors array indexes into server list. use this to determine which servers are failing
   errors?: (errors: Error[]) => void;
 };
-// this is the interface to implement a server, servers gather information about requests/assertions from any source
-export type Service = (handlers: Handlers) => {
-  start: () => void;
-  stop: () => void;
-  tick: () => void;
+
+export type Service = {
+  tick: () => Promise<void>;
 };
-export type Services = Service[];
-// This is the client to consume data on the frontend, you must configure an array of servers and provide handlers
-// to handle data coming in from servers
-export type Client = (services: Services, handlers: Handlers) => void;
+
+// this is the interface to implement a server, servers gather information about requests/assertions from any source
+export type ServiceFactory = (handlers: Handlers) => Service;
+export type ServiceFactories = ServiceFactory[];

--- a/libs/yarn.lock
+++ b/libs/yarn.lock
@@ -655,6 +655,11 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -1237,6 +1242,11 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 babel-jest@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.3.1.tgz#05c83e0d128cd48c453eea851482a38782249f44"
@@ -1461,6 +1471,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1475,6 +1492,13 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -1506,6 +1530,11 @@ deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -1779,6 +1808,11 @@ expect@^29.0.0, expect@^29.3.1:
     jest-message-util "^29.3.1"
     jest-util "^29.3.1"
 
+extract-files@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
+  integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -1861,6 +1895,15 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1956,6 +1999,16 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+graphql-request@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-5.1.0.tgz#dbc8feee27d21b993cd5da2d3af67821827b240a"
+  integrity sha512-0OeRVYigVwIiXhNmqnPDt+JhMzsjinxHE7TVy3Lm6jUzav0guVcL0lfSbi6jVTRAxcbwgyr6yrZioSHxf9gHzw==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    cross-fetch "^3.1.5"
+    extract-files "^9.0.0"
+    form-data "^3.0.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -2655,6 +2708,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2691,6 +2756,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3104,6 +3176,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 ts-jest@^29.0.5:
   version "29.0.5"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.0.5.tgz#c5557dcec8fe434fcb8b70c3e21c6b143bfce066"
@@ -3187,6 +3264,19 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^2.0.1:
   version "2.0.2"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@uma/sdk": "^0.32.4",
     "ethers": "^5.7.2",
     "framer-motion": "^8.5.0",
+    "graphql-request": "^5.1.0",
     "immer": "^9.0.18",
     "next": "13.1.2",
     "react": "18.2.0",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,7 +7,6 @@ import {
   white,
 } from "@/constants";
 import { PanelProvider } from "@/contexts";
-import oracle from "@/helpers/oracleSdk";
 import "@/styles/fonts.css";
 import { darkTheme, RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
@@ -15,8 +14,22 @@ import type { AppProps } from "next/app";
 import { configureChains, createClient, WagmiConfig } from "wagmi";
 import { infuraProvider } from "wagmi/providers/infura";
 import { publicProvider } from "wagmi/providers/public";
+import { Client, OracleType } from "@libs/oracle2";
+import { gql } from "@libs/oracle2/services";
 
-oracle && console.log("oracle client loaded");
+const gqlService = gql.Factory([
+  {
+    url: "https://api.thegraph.com/subgraphs/name/md0x/goerli-oo-staging",
+    type: OracleType.Optimistic,
+    chainId: 5,
+  },
+]);
+
+// example of using the client. hoook this up in a context / reducer
+Client([gqlService], {
+  requests: (requests) => console.log(requests),
+  errors: (errors) => console.error(errors),
+});
 
 export const { chains, provider } = configureChains(supportedChains, [
   infuraProvider({ apiKey: infuraId }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1861,6 +1861,11 @@
     teeny-request "^8.0.0"
     uuid "^8.0.0"
 
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
+
 "@grpc/grpc-js@~1.7.0":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.7.3.tgz#f2ea79f65e31622d7f86d4b4c9ae38f13ccab99a"
@@ -8579,7 +8584,7 @@ cross-fetch@^2.1.0, cross-fetch@^2.1.1:
     node-fetch "^2.6.7"
     whatwg-fetch "^2.0.4"
 
-cross-fetch@^3.1.4:
+cross-fetch@^3.1.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -10641,6 +10646,11 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-files@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
+  integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
+
 extract-zip@^1.6.6:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
@@ -11689,6 +11699,16 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+graphql-request@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-5.1.0.tgz#dbc8feee27d21b993cd5da2d3af67821827b240a"
+  integrity sha512-0OeRVYigVwIiXhNmqnPDt+JhMzsjinxHE7TVy3Lm6jUzav0guVcL0lfSbi6jVTRAxcbwgyr6yrZioSHxf9gHzw==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    cross-fetch "^3.1.5"
+    extract-files "^9.0.0"
+    form-data "^3.0.0"
 
 "graphql@^15.0.0 || ^16.0.0":
   version "16.6.0"


### PR DESCRIPTION
## motivation
We need an implementation of our data interface connecting to a real gql endpoint. 

## changes
This adds a hard coded goerli gql service and example of using it in a client in the app. We still need some environment vars, and implementations for v2 and skinny data, and eventually non gql data. 
![image](https://user-images.githubusercontent.com/4429761/217036497-3c35e691-2ff1-4de2-a19f-1831182804aa.png)
