### PR TITLE
improve: add env parsing to app config

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dom": "18.2.0",
     "react-focus-on": "^3.7.0",
     "styled-components": "^5.3.6",
+    "superstruct": "^1.0.3",
     "swr": "^2.0.1",
     "usehooks-ts": "^2.9.1",
     "wagmi": "^0.10.14"

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -1,2 +1,31 @@
-export const defaultApy = process.env.NEXT_PUBLIC_DEFAULT_APY || "30.1";
-export const infuraId = process.env.NEXT_PUBLIC_INFURA_ID || "";
+import * as ss from "superstruct";
+
+const Env = ss.object({
+  NEXT_PUBLIC_DEFAULT_APY: ss.optional(ss.string()),
+  NEXT_PUBLIC_INFURA_ID: ss.string(),
+});
+export type Env = ss.Infer<typeof Env>;
+
+const Config = ss.object({
+  defaultApy: ss.string(),
+  infuraId: ss.string(),
+});
+export type Config = ss.Infer<typeof Config>;
+
+// every prop of next envs needs to be explicitly pulled in
+const env = ss.create(
+  {
+    NEXT_PUBLIC_DEFAULT_APY: process.env.NEXT_PUBLIC_DEFAULT_APY,
+    NEXT_PUBLIC_INFURA_ID: process.env.NEXT_PUBLIC_INFURA_ID,
+  },
+  Env
+);
+
+function parseEnv(env: Env): Config {
+  return {
+    defaultApy: env.NEXT_PUBLIC_DEFAULT_APY ?? "30.1",
+    infuraId: env.NEXT_PUBLIC_INFURA_ID,
+  };
+}
+
+export const config = parseEnv(env);

--- a/src/hooks/queries.ts
+++ b/src/hooks/queries.ts
@@ -1,4 +1,4 @@
-import { defaultApy } from "@/constants";
+import { config } from "@/constants";
 import { VotingInfo } from "@/types";
 import useSWR from "swr";
 
@@ -9,7 +9,7 @@ async function getVotingInfo() {
 
 export function useVotingInfo() {
   const fallbackData = {
-    apy: defaultApy,
+    apy: config.defaultApy,
     activeRequests: 0,
     phase: "commit" as const,
   };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,6 @@
 import { GlobalStyle } from "@/components";
 import {
-  infuraId,
+  config,
   red500,
   supportedChains,
   walletsAndConnectors,
@@ -32,7 +32,7 @@ Client([gqlService], {
 });
 
 export const { chains, provider } = configureChains(supportedChains, [
-  infuraProvider({ apiKey: infuraId }),
+  infuraProvider({ apiKey: config.infuraId }),
   publicProvider(),
 ]);
 

--- a/src/stories/VoteTicker.stories.tsx
+++ b/src/stories/VoteTicker.stories.tsx
@@ -1,8 +1,9 @@
 import { VoteTicker } from "@/components/Header/VoteTicker";
-import { defaultApy } from "@/constants";
+import { config } from "@/constants";
 import type { Meta, StoryObj } from "@storybook/react";
 import { rest } from "msw";
 
+const { defaultApy } = config;
 const meta: Meta<typeof VoteTicker> = {
   component: VoteTicker,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -18139,6 +18139,11 @@ superstruct@^0.14.2:
   resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.14.2.tgz#0dbcdf3d83676588828f1cf5ed35cda02f59025b"
   integrity sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==
 
+superstruct@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-1.0.3.tgz#de626a5b49c6641ff4d37da3c7598e7a87697046"
+  integrity sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==
+
 supports-color@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.0.0.tgz#76cfe742cf1f41bb9b1c29ad03068c05b4c0e40a"


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

## motivation
oracle client configs could be pretty complicated, we want to make sure the app has a way to import and validate complex configuration. 

## changes
this is a breaking change, but the app will now parse and validate the config, which must be imported as `import {config} from 'constants'`, as opposed to previously just importing the specific value you wanted.