### PR TITLE
feat: add oracle data context

### DIFF
--- a/src/components/Header/Nav.tsx
+++ b/src/components/Header/Nav.tsx
@@ -10,8 +10,6 @@ export function Nav() {
 
   const router = useRouter();
 
-  console.log(router.pathname);
-
   function isActive(href: string) {
     return router.pathname === href;
   }

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -1,0 +1,67 @@
+import {
+  createContext,
+  ReactNode,
+  useReducer,
+  useState,
+  useEffect,
+} from "react";
+
+import { config } from "@/constants";
+import { Client, Request } from "@libs/oracle2";
+import { gql } from "@libs/oracle2/services";
+
+const gqlService = gql.Factory(config.subgraphs);
+
+export type RequestTable = Record<string, Request>;
+export type Errors = Error[];
+export interface OracleDataContextState {
+  requests: RequestTable;
+  errors: Errors;
+}
+
+export const defaultOracleDataContextState = {
+  requests: {},
+  errors: [],
+};
+
+export const OracleDataContext = createContext<OracleDataContextState>(
+  defaultOracleDataContextState
+);
+
+// most likely we want to update this to index data by state, by transaction hash, and map the shape to something the views expect.
+function requestReducer(
+  requests: RequestTable,
+  updates: Request[]
+): RequestTable {
+  updates.forEach((update) => {
+    requests[update.id] = {
+      ...(requests[update.id] || {}),
+      ...update,
+    };
+  });
+  return requests;
+}
+
+export function OracleDataProvider({ children }: { children: ReactNode }) {
+  const [requests, dispatchRequests] = useReducer(
+    requestReducer,
+    defaultOracleDataContextState.requests
+  );
+  const [errors, setErrors] = useState<Errors>(
+    defaultOracleDataContextState.errors
+  );
+
+  useEffect(() => {
+    // its important this client only gets initialized once
+    Client([gqlService], {
+      requests: dispatchRequests,
+      errors: setErrors,
+    });
+  }, []);
+
+  return (
+    <OracleDataContext.Provider value={{ errors, requests }}>
+      {children}
+    </OracleDataContext.Provider>
+  );
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -4,3 +4,5 @@ export {
   PanelProvider,
 } from "./PanelContext";
 export type { PanelContextState } from "./PanelContext";
+
+export * from "./OracleDataContext";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,7 +6,7 @@ import {
   walletsAndConnectors,
   white,
 } from "@/constants";
-import { PanelProvider } from "@/contexts";
+import { PanelProvider, OracleDataProvider } from "@/contexts";
 import "@/styles/fonts.css";
 import { darkTheme, RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
@@ -14,16 +14,6 @@ import type { AppProps } from "next/app";
 import { configureChains, createClient, WagmiConfig } from "wagmi";
 import { infuraProvider } from "wagmi/providers/infura";
 import { publicProvider } from "wagmi/providers/public";
-import { Client } from "@libs/oracle2";
-import { gql } from "@libs/oracle2/services";
-
-const gqlService = gql.Factory(config.subgraphs);
-
-// example of using the client. hoook this up in a context / reducer
-Client([gqlService], {
-  requests: (requests) => console.log(requests),
-  errors: (errors) => console.error(errors),
-});
 
 export const { chains, provider } = configureChains(supportedChains, [
   infuraProvider({ apiKey: config.infuraId }),
@@ -49,10 +39,12 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <WagmiConfig client={wagmiClient}>
       <RainbowKitProvider chains={chains} theme={rainbowKitTheme}>
-        <PanelProvider>
-          <GlobalStyle />
-          <Component {...pageProps} />
-        </PanelProvider>
+        <OracleDataProvider>
+          <PanelProvider>
+            <GlobalStyle />
+            <Component {...pageProps} />
+          </PanelProvider>
+        </OracleDataProvider>
       </RainbowKitProvider>
     </WagmiConfig>
   );


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

## motivation
we want to bring in oracle data from the graph into react

## changes
this ads a new context/provider which reduces any request updates into a table indexed by request id. this will most likely need to be updated once we know the shape and requirements for the views. 