### PR TITLE
feat: error banner

### DIFF
--- a/public/assets/icons/close.svg
+++ b/public/assets/icons/close.svg
@@ -1,3 +1,3 @@
-<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M20 2.01429L17.9857 0L10 7.98571L2.01429 0L0 2.01429L7.98571 10L0 17.9857L2.01429 20L10 12.0143L17.9857 20L20 17.9857L12.0143 10L20 2.01429Z" fill="white"/>
 </svg>

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -1,0 +1,80 @@
+import { ErrorMessage } from "@/components";
+import { tabletAndUnder } from "@/constants";
+import { useErrorContext } from "@/hooks";
+import Close from "public/assets/icons/close.svg";
+import Warning from "public/assets/icons/warning.svg";
+import styled from "styled-components";
+
+export function ErrorBanner() {
+  const { errorMessages, removeErrorMessage } = useErrorContext();
+
+  if (!errorMessages.length) return null;
+
+  return (
+    <Wrapper>
+      {errorMessages.map((errorMessage) => (
+        <ErrorMessageWrapper key={errorMessage.text}>
+          <WarningIcon />
+          <ErrorMessage {...errorMessage} />
+          <CloseButton onClick={() => removeErrorMessage(errorMessage)}>
+            <CloseIcon />
+          </CloseButton>
+        </ErrorMessageWrapper>
+      ))}
+    </Wrapper>
+  );
+}
+
+export const Wrapper = styled.div`
+  background: var(--red-500);
+  min-height: 60px;
+  max-width: 100vw;
+  color: var(--light-text);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-block: 15px;
+`;
+
+export const ErrorMessageWrapper = styled.div`
+  width: 100%;
+  max-width: var(--page-width);
+  padding-inline: var(--page-padding);
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding-block: 5px;
+  &:not(:last-child) {
+    margin-bottom: 5px;
+  }
+
+  @media ${tabletAndUnder} {
+    padding-inline: 0;
+  }
+`;
+
+export const CloseIcon = styled(Close)`
+  path {
+    fill: var(--white);
+  }
+`;
+
+export const WarningIcon = styled(Warning)``;
+
+export const CloseButton = styled.button`
+  --icon-height: 15px;
+  --icon-offset: 12px;
+  --icon-start-right: var(--page-padding);
+  --right: calc(var(--icon-start-right) + var(--icon-offset));
+  position: absolute;
+  top: calc(var(--height) - var(--icon-height) / 2px);
+  right: var(--right);
+  fill: var(--white);
+  background: transparent;
+
+  @media ${tabletAndUnder} {
+    --icon-start-right: 0px;
+  }
+`;

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -10,9 +10,15 @@ export function ErrorBanner() {
 
   if (!errorMessages.length) return null;
 
+  const uniqueErrorMessages = errorMessages.filter(
+    (errorMessage, index) =>
+      errorMessages.findIndex((error) => error.text === errorMessage.text) ===
+      index
+  );
+
   return (
     <Wrapper>
-      {errorMessages.map((errorMessage) => (
+      {uniqueErrorMessages.map((errorMessage) => (
         <ErrorMessageWrapper key={errorMessage.text}>
           <WarningIcon />
           <ErrorMessage {...errorMessage} />
@@ -27,27 +33,25 @@ export function ErrorBanner() {
 
 export const Wrapper = styled.div`
   background: var(--red-500);
-  min-height: 60px;
   max-width: 100vw;
   color: var(--light-text);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding-block: 15px;
+  padding-block: 16px;
 `;
 
 export const ErrorMessageWrapper = styled.div`
   width: 100%;
   max-width: var(--page-width);
-  padding-inline: var(--page-padding);
   position: relative;
   display: flex;
   align-items: center;
-  gap: 5px;
-  padding-block: 5px;
+  gap: 12px;
+  padding-block: 4px;
   &:not(:last-child) {
-    margin-bottom: 5px;
+    margin-bottom: 4px;
   }
 
   @media ${tabletAndUnder} {
@@ -61,20 +65,19 @@ export const CloseIcon = styled(Close)`
   }
 `;
 
-export const WarningIcon = styled(Warning)``;
+export const WarningIcon = styled(Warning)`
+  path {
+    fill: var(--white);
+    stroke: var(--red-500);
+  }
+`;
 
 export const CloseButton = styled.button`
-  --icon-height: 15px;
-  --icon-offset: 12px;
-  --icon-start-right: var(--page-padding);
-  --right: calc(var(--icon-start-right) + var(--icon-offset));
+  --icon-size: 16px;
+  width: var(--icon-size);
+  height: var(--icon-size);
   position: absolute;
-  top: calc(var(--height) - var(--icon-height) / 2px);
-  right: var(--right);
-  fill: var(--white);
+  top: calc(50% - var(--icon-size) / 2);
+  right: 0;
   background: transparent;
-
-  @media ${tabletAndUnder} {
-    --icon-start-right: 0px;
-  }
 `;

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,45 +1,19 @@
-import { ethersErrorCodes, mobileAndUnder } from "@/constants";
+import { mobileAndUnder } from "@/constants";
 import type { ErrorMessage as ErrorMessageType } from "@/types";
 import NextLink from "next/link";
 import styled from "styled-components";
 
 export function ErrorMessage({ text, link }: ErrorMessageType) {
-  const isEthersError = ethersErrorCodes.some((code) => text.includes(code));
-
-  function ethersErrorLink() {
-    if (!isEthersError) return null;
-
-    const [firstPart, secondPart] = text.split("[");
-
-    const ethersErrorLink = secondPart
-      .replace("See:", "")
-      .replace("]", "")
-      .trim();
-
-    return (
-      <span>
-        {firstPart.trim()}.{" "}
-        <Link href={ethersErrorLink} target="_blank">
-          Learn more.
-        </Link>
-      </span>
-    );
-  }
-
   return (
     <Wrapper>
-      {isEthersError ? (
-        <>{ethersErrorLink()}</>
-      ) : (
-        <span>
-          {text}.{" "}
-          {link && (
-            <Link href={link.href} target="_blank">
-              {link.text}.
-            </Link>
-          )}
-        </span>
-      )}
+      <span>
+        {text}.{" "}
+        {link && (
+          <Link href={link.href} target="_blank">
+            {link.text}.
+          </Link>
+        )}
+      </span>
     </Wrapper>
   );
 }

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,0 +1,51 @@
+import { ethersErrorCodes, mobileAndUnder } from "@/constants";
+import type { ErrorMessage as ErrorMessageType } from "@/types";
+import NextLink from "next/link";
+import styled from "styled-components";
+
+export function ErrorMessage({ text, link }: ErrorMessageType) {
+  const isEthersError = ethersErrorCodes.some((code) => text.includes(code));
+
+  const [firstPart, secondPart] = text.split("[");
+
+  const ethersErrorLink = secondPart
+    .replace("See:", "")
+    .replace("]", "")
+    .trim();
+
+  return (
+    <Wrapper>
+      {isEthersError ? (
+        <span>
+          {firstPart}.{" "}
+          <Link href={ethersErrorLink} target="_blank">
+            Learn more.
+          </Link>
+        </span>
+      ) : (
+        <span>
+          {text}.{" "}
+          {link && (
+            <Link href={link.href} target="_blank">
+              {link.text}
+            </Link>
+          )}
+        </span>
+      )}
+    </Wrapper>
+  );
+}
+
+export const Wrapper = styled.p`
+  font: var(--text-md);
+
+  @media ${mobileAndUnder} {
+    font: var(--text-xs);
+  }
+`;
+
+const Link = styled(NextLink)`
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+`;

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -6,28 +6,36 @@ import styled from "styled-components";
 export function ErrorMessage({ text, link }: ErrorMessageType) {
   const isEthersError = ethersErrorCodes.some((code) => text.includes(code));
 
-  const [firstPart, secondPart] = text.split("[");
+  function ethersErrorLink() {
+    if (!isEthersError) return null;
 
-  const ethersErrorLink = secondPart
-    .replace("See:", "")
-    .replace("]", "")
-    .trim();
+    const [firstPart, secondPart] = text.split("[");
+
+    const ethersErrorLink = secondPart
+      .replace("See:", "")
+      .replace("]", "")
+      .trim();
+
+    return (
+      <span>
+        {firstPart.trim()}.{" "}
+        <Link href={ethersErrorLink} target="_blank">
+          Learn more.
+        </Link>
+      </span>
+    );
+  }
 
   return (
     <Wrapper>
       {isEthersError ? (
-        <span>
-          {firstPart}.{" "}
-          <Link href={ethersErrorLink} target="_blank">
-            Learn more.
-          </Link>
-        </span>
+        <>{ethersErrorLink()}</>
       ) : (
         <span>
           {text}.{" "}
           {link && (
             <Link href={link.href} target="_blank">
-              {link.text}
+              {link.text}.
             </Link>
           )}
         </span>
@@ -38,9 +46,15 @@ export function ErrorMessage({ text, link }: ErrorMessageType) {
 
 export const Wrapper = styled.p`
   font: var(--text-md);
+  color: var(--light-text);
+
+  span {
+    font: inherit;
+    color: inherit;
+  }
 
   @media ${mobileAndUnder} {
-    font: var(--text-xs);
+    font: var(--body-xs);
   }
 `;
 
@@ -48,4 +62,9 @@ const Link = styled(NextLink)`
   font: inherit;
   color: inherit;
   text-decoration: underline;
+  transition: opacity var(--animation-duration);
+
+  &:hover {
+    opacity: 0.75;
+  }
 `;

--- a/src/components/GlobalStyle.tsx
+++ b/src/components/GlobalStyle.tsx
@@ -14,6 +14,7 @@ import {
   desktopNavBarHeight,
   desktopPageWidth,
   desktopPanelWidth,
+  family,
   grey100,
   grey400,
   grey50,
@@ -201,6 +202,7 @@ a:not([class]) {
   /*  All CSS custom properties that are intended to be global must be defined here */
 
   * {
+      font-family: ${family};
       color: var(--dark-text);
     }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,8 @@ export { Button } from "./Button";
 export { ConnectButton } from "./ConnectButton";
 export { DecimalInput } from "./DecimalInput";
 export { RadioDropdown } from "./Dropdown/RadioDropdown";
+export { ErrorBanner } from "./ErrorBanner";
+export { ErrorMessage as ErrorMessage } from "./ErrorMessage";
 export { Filters } from "./Filters/Filters";
 export { GlobalStyle } from "./GlobalStyle";
 export { Header } from "./Header/Header";

--- a/src/constants/styles/fonts.ts
+++ b/src/constants/styles/fonts.ts
@@ -2,7 +2,7 @@ import { css } from "styled-components";
 
 const weight = 400;
 
-const family = "'Halyard Display', sans-serif";
+export const family = "'Halyard Display', sans-serif";
 
 export const subHeader = `${weight} ${16 / 16}rem/19px ${family}`;
 export const subHeaderSm = `${weight} ${12 / 16}rem/16px ${family}`;

--- a/src/constants/wallet.ts
+++ b/src/constants/wallet.ts
@@ -42,3 +42,14 @@ export const walletsAndConnectors = getDefaultWallets({
 });
 
 export const supportedCurrencies = ["USDC", "ETH", "RY"] as const;
+
+export const ethersErrorCodes = [
+  "CALL_EXCEPTION",
+  "INSUFFICIENT_FUNDS",
+  "MISSING_NEW",
+  "NONCE_EXPIRED",
+  "NUMERIC_FAULT",
+  "REPLACEMENT_UNDERPRICED",
+  "TRANSACTION_REPLACED",
+  "UNPREDICTABLE_GAS_LIMIT",
+];

--- a/src/contexts/ErrorContext.tsx
+++ b/src/contexts/ErrorContext.tsx
@@ -1,12 +1,5 @@
+import { ErrorMessage } from "@/types";
 import { createContext, ReactNode, useState } from "react";
-
-type ErrorMessage = {
-  text: string;
-  link?: {
-    text: string;
-    href: string;
-  };
-};
 
 export interface ErrorContextState {
   errorMessages: ErrorMessage[];

--- a/src/contexts/ErrorContext.tsx
+++ b/src/contexts/ErrorContext.tsx
@@ -23,6 +23,7 @@ export function ErrorProvider({ children }: { children: ReactNode }) {
   const [errorMessages, setErrorMessages] = useState<ErrorMessage[]>([]);
 
   function addErrorMessage(errorMessage: ErrorMessage) {
+    if (errorMessage.text === "") return;
     setErrorMessages([...errorMessages, errorMessage]);
   }
 

--- a/src/contexts/ErrorContext.tsx
+++ b/src/contexts/ErrorContext.tsx
@@ -1,0 +1,58 @@
+import { createContext, ReactNode, useState } from "react";
+
+type ErrorMessage = {
+  text: string;
+  link?: {
+    text: string;
+    href: string;
+  };
+};
+
+export interface ErrorContextState {
+  errorMessages: ErrorMessage[];
+  addErrorMessage: (errorMessage: ErrorMessage) => void;
+  removeErrorMessage: (errorMessage: ErrorMessage) => void;
+  clearErrorMessages: () => void;
+}
+
+export const defaultErrorContextState: ErrorContextState = {
+  errorMessages: [],
+  addErrorMessage: () => undefined,
+  removeErrorMessage: () => undefined,
+  clearErrorMessages: () => undefined,
+};
+
+export const ErrorContext = createContext<ErrorContextState>(
+  defaultErrorContextState
+);
+
+export function ErrorProvider({ children }: { children: ReactNode }) {
+  const [errorMessages, setErrorMessages] = useState<ErrorMessage[]>([]);
+
+  function addErrorMessage(errorMessage: ErrorMessage) {
+    setErrorMessages([...errorMessages, errorMessage]);
+  }
+
+  function removeErrorMessage(errorMessage: ErrorMessage) {
+    setErrorMessages(
+      errorMessages.filter(({ text }) => text !== errorMessage.text)
+    );
+  }
+
+  function clearErrorMessages() {
+    setErrorMessages([]);
+  }
+
+  return (
+    <ErrorContext.Provider
+      value={{
+        errorMessages,
+        addErrorMessage,
+        removeErrorMessage,
+        clearErrorMessages,
+      }}
+    >
+      {children}
+    </ErrorContext.Provider>
+  );
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,4 +1,10 @@
 export {
+  defaultErrorContextState,
+  ErrorContext,
+  ErrorProvider,
+} from "./ErrorContext";
+export type { ErrorContextState } from "./ErrorContext";
+export {
   defaultPanelContextState,
   PanelContext,
   PanelProvider,

--- a/src/helpers/ethers.ts
+++ b/src/helpers/ethers.ts
@@ -1,3 +1,4 @@
+import { ethersErrorCodes } from "@/constants";
 import { ethers } from "ethers";
 
 export const formatEther = ethers.utils.formatEther;
@@ -37,3 +38,34 @@ export const isAddress = ethers.utils.isAddress;
 export const oneEth = ethers.BigNumber.from("1000000000000000000");
 
 export const maximumApprovalAmount = ethers.constants.MaxUint256;
+
+/**
+ * Matches given text against the list of known ethers error codes.
+ * @param text - the text to match
+ * @returns true if the text matches an error code, false otherwise
+ */
+export function isEthersError(text: string) {
+  return ethersErrorCodes.some((code) => text.includes(code));
+}
+
+/**
+ * Parses an ethers error into a message part and a link part.
+ * Conforms to the `ErrorMessage` type.
+ * @param ethersError - the error to parse
+ * @returns the parsed error
+ */
+export function parseEthersError(ethersError: string) {
+  const [firstPart, secondPart] = ethersError.split("[");
+
+  const text = firstPart.trim();
+
+  const href = secondPart.replace("See:", "").replace("]", "").trim();
+
+  return {
+    text,
+    link: {
+      text: "Learn more",
+      href,
+    },
+  };
+}

--- a/src/hooks/contexts.ts
+++ b/src/hooks/contexts.ts
@@ -1,4 +1,6 @@
-import { PanelContext } from "@/contexts";
+import { ErrorContext, PanelContext } from "@/contexts";
 import { useContext } from "react";
 
 export const usePanelContext = () => useContext(PanelContext);
+
+export const useErrorContext = () => useContext(ErrorContext);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,16 +6,16 @@ import {
   walletsAndConnectors,
   white,
 } from "@/constants";
-import { PanelProvider } from "@/contexts";
+import { ErrorProvider, PanelProvider } from "@/contexts";
 import "@/styles/fonts.css";
+import { Client } from "@libs/oracle2";
+import { gql } from "@libs/oracle2/services";
 import { darkTheme, RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
 import type { AppProps } from "next/app";
 import { configureChains, createClient, WagmiConfig } from "wagmi";
 import { infuraProvider } from "wagmi/providers/infura";
 import { publicProvider } from "wagmi/providers/public";
-import { Client } from "@libs/oracle2";
-import { gql } from "@libs/oracle2/services";
 
 const gqlService = gql.Factory(config.subgraphs);
 
@@ -49,10 +49,12 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <WagmiConfig client={wagmiClient}>
       <RainbowKitProvider chains={chains} theme={rainbowKitTheme}>
-        <PanelProvider>
-          <GlobalStyle />
-          <Component {...pageProps} />
-        </PanelProvider>
+        <ErrorProvider>
+          <PanelProvider>
+            <GlobalStyle />
+            <Component {...pageProps} />
+          </PanelProvider>
+        </ErrorProvider>
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/src/stories/ErrorBanner.stories.tsx
+++ b/src/stories/ErrorBanner.stories.tsx
@@ -1,5 +1,6 @@
 import { Button, ErrorBanner } from "@/components";
 import { ErrorContext, ErrorContextState } from "@/contexts";
+import { parseEthersError } from "@/helpers";
 import { ErrorMessage } from "@/types";
 import { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
@@ -193,9 +194,9 @@ export const EthersErrorMessage: Story = {
   ...Template,
   args: {
     errorMessages: [
-      {
-        text: `Error: overflow [See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow]`,
-      },
+      parseEthersError(
+        "Error: overflow [See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow]"
+      ),
     ],
   },
 };

--- a/src/stories/ErrorBanner.stories.tsx
+++ b/src/stories/ErrorBanner.stories.tsx
@@ -1,0 +1,214 @@
+import { Button, ErrorBanner } from "@/components";
+import { ErrorContext, ErrorContextState } from "@/contexts";
+import { ErrorMessage } from "@/types";
+import { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import styled from "styled-components";
+
+const meta: Meta<typeof ErrorBanner> = {
+  component: ErrorBanner,
+};
+
+export default meta;
+
+type Story = StoryObj<ErrorContextState>;
+
+interface Props {
+  Component: typeof ErrorBanner;
+  errorMessages?: ErrorContextState["errorMessages"];
+}
+function Wrapper({ Component, errorMessages }: Props) {
+  const [_errorMessages, _setErrorMessages] = useState(errorMessages ?? []);
+
+  const [errorMessageTextInput, setErrorMessageTextInput] = useState("");
+  const [errorMessageLinkTextInput, setErrorMessageLinkTextInput] =
+    useState("");
+  const [errorMessageLinkHrefInput, setErrorMessageLinkHrefInput] =
+    useState("");
+  const [removeErrorMessageTextInput, setRemoveErrorMessageTextInput] =
+    useState("");
+
+  function addErrorMessage(errorMessage: ErrorMessage) {
+    if (errorMessage.text === "") return;
+    _setErrorMessages([..._errorMessages, errorMessage]);
+  }
+
+  function removeErrorMessage(errorMessage: ErrorMessage) {
+    _setErrorMessages(
+      _errorMessages.filter(({ text }) => text !== errorMessage.text)
+    );
+  }
+
+  function clearErrorMessages() {
+    _setErrorMessages([]);
+  }
+  return (
+    <ErrorContext.Provider
+      value={{
+        errorMessages: _errorMessages,
+        addErrorMessage,
+        removeErrorMessage,
+        clearErrorMessages,
+      }}
+    >
+      <Component />
+      <InputWrapper>
+        <Input
+          type="text"
+          onChange={(e) => setErrorMessageTextInput(e.currentTarget.value)}
+          value={errorMessageTextInput}
+          placeholder="Error message text"
+        />
+        <Input
+          type="text"
+          onChange={(e) => setErrorMessageLinkTextInput(e.currentTarget.value)}
+          value={errorMessageLinkTextInput}
+          placeholder="Error message link text"
+        />
+        <Input
+          type="text"
+          onChange={(e) => setErrorMessageLinkHrefInput(e.currentTarget.value)}
+          value={errorMessageLinkHrefInput}
+          placeholder="Error message link href"
+        />
+        <Button
+          variant="primary"
+          onClick={() => {
+            addErrorMessage({
+              text: errorMessageTextInput,
+              link:
+                errorMessageTextInput && errorMessageLinkHrefInput
+                  ? {
+                      text: errorMessageLinkTextInput,
+                      href: errorMessageLinkHrefInput,
+                    }
+                  : undefined,
+            });
+            setErrorMessageTextInput("");
+            setErrorMessageLinkTextInput("");
+          }}
+        >
+          Add error message
+        </Button>
+      </InputWrapper>
+      <InputWrapper>
+        <Input
+          type="text"
+          onChange={(e) =>
+            setRemoveErrorMessageTextInput(e.currentTarget.value)
+          }
+          value={removeErrorMessageTextInput}
+          placeholder="Error message text"
+        />
+        <Button
+          variant="primary"
+          onClick={() => {
+            removeErrorMessage({ text: removeErrorMessageTextInput });
+            setRemoveErrorMessageTextInput("");
+          }}
+        >
+          Remove error message
+        </Button>
+      </InputWrapper>
+      <Button
+        variant="primary"
+        onClick={() => {
+          clearErrorMessages();
+        }}
+      >
+        Clear error messages
+      </Button>
+    </ErrorContext.Provider>
+  );
+}
+
+const Template: Story = {
+  render: (args) => <Wrapper Component={ErrorBanner} {...args} />,
+};
+
+export const NoMessages: Story = {
+  ...Template,
+};
+
+export const OneErrorMessage: Story = {
+  ...Template,
+  args: {
+    errorMessages: [
+      {
+        text: "This is an error message",
+        link: {
+          text: "This is a link",
+          href: "https://google.com",
+        },
+      },
+    ],
+  },
+};
+
+export const MultipleErrorMessages: Story = {
+  ...Template,
+  args: {
+    errorMessages: [
+      {
+        text: "This is an error message",
+        link: {
+          text: "This is a link",
+          href: "https://google.com",
+        },
+      },
+      {
+        text: "This is another error message",
+        link: {
+          text: "This is another link",
+          href: "https://google.com",
+        },
+      },
+    ],
+  },
+};
+
+export const MultipleOfTheSameErrorMessage: Story = {
+  ...Template,
+  args: {
+    errorMessages: [
+      {
+        text: "This is an error message",
+        link: {
+          text: "This is a link",
+          href: "https://google.com",
+        },
+      },
+      {
+        text: "This is an error message",
+        link: {
+          text: "This is a link",
+          href: "https://google.com",
+        },
+      },
+    ],
+  },
+};
+
+export const EthersErrorMessage: Story = {
+  ...Template,
+  args: {
+    errorMessages: [
+      {
+        text: `Error: overflow [See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow]`,
+      },
+    ],
+  },
+};
+
+const InputWrapper = styled.div`
+  display: flex;
+  gap: 32px;
+  margin-block: 32px;
+`;
+
+const Input = styled.input`
+  padding-inline: 8px;
+  padding-block: 4px;
+  border: 1px solid var(--blue-grey-700);
+  border-radius: 4px;
+`;

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -60,3 +60,11 @@ export type MoreInformationItem = {
   text: string;
   href: string;
 };
+
+export type ErrorMessage = {
+  text: string;
+  link?: {
+    text: string;
+    href: string;
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
### Motivation

Add an error banner component with an associated context. I've elected to keep this context separate from the errors that may show in the panel because I expect that we will handle the error states of actions that the user takes in the functions that transform data for the UI. This banner and context is only intended for showing global errors for things like the graph not working or the user being connected to an unsupported network.

**[Story](https://63d101d13121a53332f6218c-jukricodil.chromatic.com/?path=/story/stories-errorbanner--no-messages)**

### Changes

* add error banner component
* add error context