### PR TITLE
feat: add full UI interface, page hook

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,3 +3,4 @@ export * from "./filters";
 export * from "./helpers";
 export * from "./queries";
 export * from "./actions";
+export * from "./page";

--- a/src/hooks/page.ts
+++ b/src/hooks/page.ts
@@ -1,0 +1,24 @@
+import { useOracleDataContext, useFilterAndSearch } from "@/hooks";
+import type { PageName } from "@/types";
+
+type FilterState = ReturnType<typeof useFilterAndSearch>;
+type PageState = FilterState & { name: PageName; isLoading: boolean };
+export function usePage(name: PageName): PageState {
+  const { settled, propose, verify } = useOracleDataContext();
+  const queries =
+    name === "verify"
+      ? verify
+      : name === "propose"
+      ? propose
+      : name === "settled"
+      ? settled
+      : undefined;
+  const filterAndSearch = useFilterAndSearch(queries);
+  const isLoading = queries === undefined;
+
+  return {
+    name,
+    isLoading,
+    ...filterAndSearch,
+  };
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,17 +1,16 @@
 import { Filters, Layout, OracleQueries } from "@/components";
-import { useFilterAndSearch, useOracleDataContext } from "@/hooks";
+import { usePage } from "@/hooks";
 
+const pageName = "verify";
 export default function Verify() {
-  const { verify } = useOracleDataContext();
-  const { results, searchProps, filterProps } = useFilterAndSearch(verify);
-
+  const page = usePage(pageName);
   return (
     <Layout>
-      <Filters {...filterProps} {...searchProps} />
+      <Filters {...page.filterProps} {...page.searchProps} />
       <OracleQueries
-        queries={results}
-        isLoading={verify === undefined}
-        page="verify"
+        queries={page.results}
+        isLoading={page.isLoading}
+        page={page.name}
       />
     </Layout>
   );

--- a/src/pages/propose.tsx
+++ b/src/pages/propose.tsx
@@ -1,17 +1,16 @@
 import { Filters, Layout, OracleQueries } from "@/components";
-import { useFilterAndSearch, useOracleDataContext } from "@/hooks";
+import { usePage } from "@/hooks";
 
-export default function Propose() {
-  const { propose } = useOracleDataContext();
-  const { results, searchProps, filterProps } = useFilterAndSearch(propose);
-
+const pageName = "propose";
+export default function Verify() {
+  const page = usePage(pageName);
   return (
     <Layout>
-      <Filters {...filterProps} {...searchProps} />
+      <Filters {...page.filterProps} {...page.searchProps} />
       <OracleQueries
-        queries={results}
-        isLoading={propose === undefined}
-        page="propose"
+        queries={page.results}
+        isLoading={page.isLoading}
+        page={page.name}
       />
     </Layout>
   );

--- a/src/pages/settled.tsx
+++ b/src/pages/settled.tsx
@@ -1,17 +1,16 @@
 import { Filters, Layout, OracleQueries } from "@/components";
-import { useFilterAndSearch, useOracleDataContext } from "@/hooks";
+import { usePage } from "@/hooks";
 
-export default function Propose() {
-  const { settled } = useOracleDataContext();
-  const { results, searchProps, filterProps } = useFilterAndSearch(settled);
-
+const pageName = "settled";
+export default function Verify() {
+  const page = usePage(pageName);
   return (
     <Layout>
-      <Filters {...filterProps} {...searchProps} />
+      <Filters {...page.filterProps} {...page.searchProps} />
       <OracleQueries
-        queries={results}
-        isLoading={settled === undefined}
-        page="settled"
+        queries={page.results}
+        isLoading={page.isLoading}
+        page={page.name}
       />
     </Layout>
   );

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -6,6 +6,7 @@ import type {
   oracleTypes,
   projects,
 } from "@/constants";
+import type { BigNumber } from "ethers";
 import type { DropdownMenuCheckboxItemProps } from "@radix-ui/react-dropdown-menu";
 import type { ReactNode } from "react";
 export type ActionType =
@@ -50,6 +51,124 @@ export type OracleQueryUI = {
   formattedReward: string | undefined;
   assertion: boolean | undefined;
 };
+export type BigNumberish = string | number | BigNumber;
+
+export type Tag = {
+  icon: string;
+  text: string;
+};
+export type Time = {
+  unix: string;
+  utc: string;
+};
+export type Token = {
+  // details
+  decimals: number;
+  symbol: string;
+  icon: string;
+  // actions
+  formatAmount: (wei: BigNumberish) => string;
+  approve: (address: string, spender: string, amount: BigNumberish) => void;
+  balance: (address: string) => void;
+  details: () => void;
+};
+export type Amount = {
+  formatted: string;
+  icon: string;
+};
+export type QuerySummary = {
+  icon: string;
+  title: string;
+  subtitle: {
+    project: string;
+    timestamp: string;
+    chain: string;
+    expiryType: string;
+    formatted: string;
+  };
+  click: () => void;
+};
+export type VerifyQuerySummary = QuerySummary & {
+  proposal: string;
+  startTime: number;
+  endTime: number;
+};
+
+export type ProposeQuerySummary = QuerySummary & {
+  bond: Amount;
+  reward: Amount;
+};
+
+export type SettledQuerySummary = QuerySummary & {
+  result: string;
+};
+
+export type QueryDetails = {
+  timestamp: Time;
+  ancillaryData: {
+    formatted: string;
+    bytes: string;
+  };
+  tags: Tag[];
+  moreInfo: MoreInformationItem[];
+  error: ErrorMessage;
+  primaryAction: {
+    disabled: boolean;
+    tooltip: string;
+    submit: (input?: BigNumberish) => void;
+    label: string;
+  };
+};
+export type VerifyQueryDetails = QueryDetails & {
+  bond: Amount;
+  reward: Amount;
+  bondToken: Token;
+  rewardToken: Token;
+  proposal: string;
+  expiry: string;
+  dispute: () => void;
+};
+
+export type VerifyQuery = {
+  type: "verify";
+  summary: VerifyQuerySummary;
+  details: VerifyQueryDetails;
+};
+export type ProposeQueryDetails = QueryDetails & {
+  bond: Amount;
+  reward: Amount;
+  bondToken: Token;
+  rewardToken: Token;
+  challengePeriod: string;
+  propose: (value: BigNumberish) => void;
+};
+export type ProposeQuery = {
+  type: "propose";
+  summary: ProposeQuerySummary;
+  details: ProposeQueryDetails;
+};
+
+export type LifeCycleDetail = {
+  icon: string;
+  name: string;
+  address: string;
+  href: string;
+  timeFormatted: string;
+};
+export type SettledQueryDetails = QueryDetails & {
+  proposal: string;
+  lifecycle: LifeCycleDetail[];
+  settle: () => void;
+};
+
+export type SettledQuery = {
+  type: "settled";
+  summary: SettledQuerySummary;
+  details: SettledQueryDetails;
+};
+
+export type OracleQuery = SettledQuery | ProposeQuery | VerifyQuery;
+export type OracleQueries = OracleQuery[];
 
 export type OracleTypes = typeof oracleTypes;
 
@@ -116,3 +235,5 @@ export type CheckedChangePayload = {
 };
 
 export type OnCheckedChange = (payload: CheckedChangePayload) => void;
+
+export type PageName = "verify" | "propose" | "settled";


### PR DESCRIPTION
## motivation
We want to create an api for the app that makes it clean to render according to design

## changes
rather than try to implement functionality, this defines the data that we will need for each part of the UI only at the page level. We can fill in this data in subsequent PRs. This also abstracts the page data into a hook which can also be used for eventually filling in the needed data.