### PR TITLE
feat: add oracle v2 gql data

### DIFF
--- a/libs/src/constants.ts
+++ b/libs/src/constants.ts
@@ -46,6 +46,42 @@ export const ContractInfoList: ContractInfoList = [
     chainId: 42161,
     address: getAddress("0x031A7882cE3e8b4462b057EBb0c3F23Cd731D234"),
   },
+  // v2
+  {
+    type: "Optimistic Oracle V2",
+    chainId: 1,
+    address: getAddress("0xA0Ae6609447e57a42c51B50EAe921D701823FFAe"),
+  },
+  {
+    // goerli
+    type: "Optimistic Oracle V2",
+    chainId: 5,
+    address: getAddress("0xA5B9d8a0B0Fa04Ba71BDD68069661ED5C0848884"),
+  },
+  {
+    // optimism
+    type: "Optimistic Oracle V2",
+    chainId: 10,
+    address: getAddress("0x255483434aba5a75dc60c1391bB162BCd9DE2882"),
+  },
+  {
+    // polygon
+    type: "Optimistic Oracle V2",
+    chainId: 137,
+    address: getAddress("0xee3afe347d5c74317041e2618c49534daf887c24"),
+  },
+  {
+    // boba
+    type: "Optimistic Oracle V2",
+    chainId: 288,
+    address: getAddress("0xb2b5C1b17B19d92CC4fC1f026B2133259e3ccd41"),
+  },
+  {
+    // arbitrum
+    type: "Optimistic Oracle V2",
+    chainId: 42161,
+    address: getAddress("0x88Ad27C41AD06f01153E7Cd9b10cBEdF4616f4d5"),
+  },
   // v3
   {
     type: "Optimistic Oracle V3",

--- a/libs/src/oracle2/services/oracleV1/gql/factory.ts
+++ b/libs/src/oracle2/services/oracleV1/gql/factory.ts
@@ -1,4 +1,9 @@
-import type { Service, Handlers, ServiceFactory } from "../../../types";
+import type {
+  Service,
+  Handlers,
+  ServiceFactory,
+  OracleType,
+} from "../../../types";
 import { convert } from "./utils";
 import { getRequests } from "./queries";
 
@@ -6,14 +11,17 @@ export type Config = {
   url: string;
   chainId: number;
   address: string;
+  type: OracleType;
 };
 
 export const Factory =
   (config: Config): ServiceFactory =>
   (handlers: Handlers): Service => {
-    async function fetch({ url, chainId, address }: Config) {
+    async function fetch({ url, chainId, address, type }: Config) {
       const requests = await getRequests(url);
-      return requests.map((request) => convert(request, chainId, address));
+      return requests.map((request) =>
+        convert(request, chainId, address, type)
+      );
     }
     async function tick() {
       if (handlers.requests) {

--- a/libs/src/oracle2/services/oracleV1/gql/utils.ts
+++ b/libs/src/oracle2/services/oracleV1/gql/utils.ts
@@ -1,5 +1,5 @@
 import type { OptimisticPriceRequest } from "./queries";
-import type { Request } from "../../../types";
+import type { Request, OracleType } from "../../../types";
 import { RequestState } from "../../../types";
 
 export function isRequestState(
@@ -12,7 +12,8 @@ export function isRequestState(
 export function convert(
   request: OptimisticPriceRequest,
   chainId: number,
-  oracleAddress: string
+  oracleAddress: string,
+  oracleType: OracleType
 ): Request {
   return {
     // request key
@@ -23,7 +24,7 @@ export function convert(
     // meta data
     chainId,
     oracleAddress,
-    oracleType: "Optimistic Oracle V1",
+    oracleType,
     id: request.id,
     // everything else
     proposer: request.proposer,

--- a/libs/src/oracle2/services/oracles/factory.ts
+++ b/libs/src/oracle2/services/oracles/factory.ts
@@ -24,6 +24,10 @@ export const Factory =
       if (config.source === "gql" && config.type === "Optimistic Oracle V1") {
         return gqlV1.Factory(config)(handlers);
       }
+      // note that v2 queries are essentially the same shape as v1, so we reuse the service
+      if (config.source === "gql" && config.type === "Optimistic Oracle V2") {
+        return gqlV1.Factory(config)(handlers);
+      }
       if (config.source === "gql" && config.type === "Optimistic Oracle V3") {
         return gqlV3.Factory(config)(handlers);
       }

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -16,12 +16,21 @@ const Env = ss.object({
   NEXT_PUBLIC_SUBGRAPH_V1_42161: ss.optional(ss.string()),
   // goerli
   NEXT_PUBLIC_SUBGRAPH_V1_5: ss.optional(ss.string()),
+
+  NEXT_PUBLIC_SUBGRAPH_V2_1: ss.optional(ss.string()),
+  NEXT_PUBLIC_SUBGRAPH_V2_10: ss.optional(ss.string()),
+  NEXT_PUBLIC_SUBGRAPH_V2_137: ss.optional(ss.string()),
+  NEXT_PUBLIC_SUBGRAPH_V2_288: ss.optional(ss.string()),
+  NEXT_PUBLIC_SUBGRAPH_V2_42161: ss.optional(ss.string()),
+  NEXT_PUBLIC_SUBGRAPH_V2_5: ss.optional(ss.string()),
+
   NEXT_PUBLIC_SUBGRAPH_V3_1: ss.optional(ss.string()),
   NEXT_PUBLIC_SUBGRAPH_V3_10: ss.optional(ss.string()),
   NEXT_PUBLIC_SUBGRAPH_V3_137: ss.optional(ss.string()),
   NEXT_PUBLIC_SUBGRAPH_V3_288: ss.optional(ss.string()),
   NEXT_PUBLIC_SUBGRAPH_V3_42161: ss.optional(ss.string()),
   NEXT_PUBLIC_SUBGRAPH_V3_5: ss.optional(ss.string()),
+
   NEXT_PUBLIC_PROVIDER_1: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_137: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_288: ss.optional(ss.string()),
@@ -46,12 +55,20 @@ const env = ss.create(
     NEXT_PUBLIC_SUBGRAPH_V1_42161: process.env.NEXT_PUBLIC_SUBGRAPH_V1_42161,
     NEXT_PUBLIC_SUBGRAPH_V1_5: process.env.NEXT_PUBLIC_SUBGRAPH_V1_5,
 
+    NEXT_PUBLIC_SUBGRAPH_V2_1: process.env.NEXT_PUBLIC_SUBGRAPH_V2_1,
+    NEXT_PUBLIC_SUBGRAPH_V2_10: process.env.NEXT_PUBLIC_SUBGRAPH_V2_10,
+    NEXT_PUBLIC_SUBGRAPH_V2_137: process.env.NEXT_PUBLIC_SUBGRAPH_V2_137,
+    NEXT_PUBLIC_SUBGRAPH_V2_288: process.env.NEXT_PUBLIC_SUBGRAPH_V2_288,
+    NEXT_PUBLIC_SUBGRAPH_V2_42161: process.env.NEXT_PUBLIC_SUBGRAPH_V2_42161,
+    NEXT_PUBLIC_SUBGRAPH_V2_5: process.env.NEXT_PUBLIC_SUBGRAPH_V2_5,
+
     NEXT_PUBLIC_SUBGRAPH_V3_1: process.env.NEXT_PUBLIC_SUBGRAPH_V3_1,
     NEXT_PUBLIC_SUBGRAPH_V3_10: process.env.NEXT_PUBLIC_SUBGRAPH_V3_10,
     NEXT_PUBLIC_SUBGRAPH_V3_137: process.env.NEXT_PUBLIC_SUBGRAPH_V3_137,
     NEXT_PUBLIC_SUBGRAPH_V3_288: process.env.NEXT_PUBLIC_SUBGRAPH_V3_288,
     NEXT_PUBLIC_SUBGRAPH_V3_42161: process.env.NEXT_PUBLIC_SUBGRAPH_V3_42161,
     NEXT_PUBLIC_SUBGRAPH_V3_5: process.env.NEXT_PUBLIC_SUBGRAPH_V3_5,
+
     NEXT_PUBLIC_PROVIDER_1: process.env.NEXT_PUBLIC_PROVIDER_1,
     NEXT_PUBLIC_PROVIDER_137: process.env.NEXT_PUBLIC_PROVIDER_137,
     NEXT_PUBLIC_PROVIDER_288: process.env.NEXT_PUBLIC_PROVIDER_288,
@@ -168,6 +185,74 @@ function parseEnv(env: Env): Config {
       address: getContractAddress({ chainId: 5, type: "Optimistic Oracle V1" }),
     });
   }
+
+  if (env.NEXT_PUBLIC_SUBGRAPH_V2_1) {
+    subgraphs.push({
+      source: "gql",
+      url: env.NEXT_PUBLIC_SUBGRAPH_V2_1,
+      type: "Optimistic Oracle V2",
+      chainId: 1,
+      address: getContractAddress({ chainId: 1, type: "Optimistic Oracle V2" }),
+    });
+  }
+  if (env.NEXT_PUBLIC_SUBGRAPH_V2_10) {
+    subgraphs.push({
+      source: "gql",
+      url: env.NEXT_PUBLIC_SUBGRAPH_V2_10,
+      type: "Optimistic Oracle V2",
+      chainId: 10,
+      address: getContractAddress({
+        chainId: 10,
+        type: "Optimistic Oracle V2",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_SUBGRAPH_V2_137) {
+    subgraphs.push({
+      source: "gql",
+      url: env.NEXT_PUBLIC_SUBGRAPH_V2_137,
+      type: "Optimistic Oracle V2",
+      chainId: 137,
+      address: getContractAddress({
+        chainId: 137,
+        type: "Optimistic Oracle V2",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_SUBGRAPH_V2_288) {
+    subgraphs.push({
+      source: "gql",
+      url: env.NEXT_PUBLIC_SUBGRAPH_V2_288,
+      type: "Optimistic Oracle V2",
+      chainId: 288,
+      address: getContractAddress({
+        chainId: 288,
+        type: "Optimistic Oracle V2",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_SUBGRAPH_V2_42161) {
+    subgraphs.push({
+      source: "gql",
+      url: env.NEXT_PUBLIC_SUBGRAPH_V2_42161,
+      type: "Optimistic Oracle V2",
+      chainId: 42161,
+      address: getContractAddress({
+        chainId: 42161,
+        type: "Optimistic Oracle V2",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_SUBGRAPH_V2_5) {
+    subgraphs.push({
+      source: "gql",
+      url: env.NEXT_PUBLIC_SUBGRAPH_V2_5,
+      type: "Optimistic Oracle V2",
+      chainId: 5,
+      address: getContractAddress({ chainId: 5, type: "Optimistic Oracle V2" }),
+    });
+  }
+
   if (env.NEXT_PUBLIC_SUBGRAPH_V3_1) {
     subgraphs.push({
       source: "gql",

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -82,7 +82,7 @@ export function requestToOracleQuery(request: Request): OracleQueryUI {
     chainName: isSupportedChain(request.chainId)
       ? getChainName(request.chainId)
       : getChainName(0),
-    oracleType: "Optimistic Oracle V1",
+    oracleType: request.oracleType,
     oracleAddress: request.oracleAddress,
     ancillaryData: request.ancillaryData,
     decodedAncillaryData: decodeAncillaryData(request.ancillaryData),


### PR DESCRIPTION
## motivation
we want to add oracle v2 gql endpoints to app now that its available

## changes
This re-uses the v1 service, afaik the data structures are the same, and adds the env config to enable it