### PR TITLE
feat: add skinny oo contract interactions

### DIFF
--- a/shared/constants/abi.ts
+++ b/shared/constants/abi.ts
@@ -14,7 +14,7 @@ export const proposePriceAbi = [
   },
 ];
 
-export const skinnyProposePriceAbi = {
+export const skinnyProposePriceAbi = [{
   inputs: [
     { internalType: "address", name: "requester", type: "address" },
     { internalType: "bytes32", name: "identifier", type: "bytes32" },
@@ -48,7 +48,7 @@ export const skinnyProposePriceAbi = {
   outputs: [{ internalType: "uint256", name: "totalBond", type: "uint256" }],
   stateMutability: "nonpayable",
   type: "function",
-};
+}];
 
 export const disputePriceAbi = [
   {

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -32,9 +32,6 @@ export function useActions(
     config: proposePriceConfig,
     error: prepareProposePriceError,
     isLoading: isPrepareProposePriceLoading,
-    // unable to get this to pass typescript, something wrong with abi type
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
   } = usePrepareContractWrite(proposePriceParams?.(proposePriceInput));
   const {
     config: disputePriceConfig,
@@ -45,9 +42,6 @@ export function useActions(
     config: settlePriceConfig,
     error: prepareSettlePriceError,
     isLoading: isPrepareSettlePriceLoading,
-    // unable to get this to pass typescript, something wrong with abi type
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
   } = usePrepareContractWrite(settlePriceParams);
   const {
     config: disputeAssertionConfig,

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -32,6 +32,9 @@ export function useActions(
     config: proposePriceConfig,
     error: prepareProposePriceError,
     isLoading: isPrepareProposePriceLoading,
+    // unable to get this to pass typescript, something wrong with abi type
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
   } = usePrepareContractWrite(proposePriceParams?.(proposePriceInput));
   const {
     config: disputePriceConfig,
@@ -42,6 +45,9 @@ export function useActions(
     config: settlePriceConfig,
     error: prepareSettlePriceError,
     isLoading: isPrepareSettlePriceLoading,
+    // unable to get this to pass typescript, something wrong with abi type
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
   } = usePrepareContractWrite(settlePriceParams);
   const {
     config: disputeAssertionConfig,


### PR DESCRIPTION
## motivation
skinny oo contract interactions need to be added

## changes
skinny oo contract mutations require the entire request body, which needs to be formatted based on its latest state. this adds the utilities to do this and attempts to create the action functions for this.  there were issues building when passing abis into wagmi, so those lines were disabled for typescript. 