### PR TITLE
feat: allow action button to connect and switch chains

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,7 @@ export { ErrorMessage } from "./ErrorMessage";
 export { Filters } from "./Filters/Filters";
 export { GlobalStyle } from "./GlobalStyle";
 export { Header } from "./Header/Header";
+export { ConnectButton } from "./Header/ConnectButton";
 export { IconWrapper } from "./IconWrapper";
 export { Layout } from "./Layout";
 export { OracleQueries } from "./OracleQueries";

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -72,10 +72,7 @@ function DataReducerFactory<Input extends Request | Assertion>(
     const queries = Object.values(all).reduce((result, query) => {
       if (query.actionType === "propose") {
         result.propose.push(query);
-      } else if (
-        query.actionType === "dispute" ||
-        query.actionType === "settle"
-      ) {
+      } else if (query.actionType === "dispute") {
         result.verify.push(query);
       } else {
         result.settled.push(query);

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -208,7 +208,7 @@ function makeProposePriceParams({
   oracleAddress: Address;
   chainId: ChainId;
 }) {
-  return (proposedPrice: string) => {
+  return (proposedPrice?: string) => {
     if (!proposedPrice) return;
     return {
       address: oracleAddress,
@@ -243,7 +243,7 @@ function makeProposePriceSkinnyParams({
   chainId: ChainId;
   request: SolidityRequest;
 }) {
-  return (proposedPrice: string) => {
+  return (proposedPrice?: string) => {
     if (!proposedPrice) return;
     return {
       address: oracleAddress,
@@ -591,6 +591,7 @@ export function requestToOracleQuery(request: Request): OracleQueryUI {
     proposalTimestamp,
     proposalHash,
     proposalLogIndex,
+    state,
   };
 }
 

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -1,4 +1,5 @@
 import { Currency } from "@/components";
+import { useBalanceAndAllowance } from "@/hooks";
 import { handleNotifications } from "@/helpers";
 import type { OracleQueryUI } from "@/types";
 import { useEffect } from "react";
@@ -6,299 +7,456 @@ import {
   useAccount,
   useContractWrite,
   usePrepareContractWrite,
+  useNetwork,
+  useSwitchNetwork,
+  useConnect,
   useWaitForTransaction,
 } from "wagmi";
 
-export function useActions(
-  query: OracleQueryUI | undefined,
-  proposePriceInput: string
-) {
-  const { address } = useAccount();
-  const {
-    approveBondSpendParams,
-    proposePriceParams,
-    disputePriceParams,
-    settlePriceParams,
-    disputeAssertionParams,
-    settleAssertionParams,
-  } = query ?? {};
+// This represents an action button, and the state we need to render it
+export type ActionState = Partial<{
+  action: () => void;
+  disabled: boolean;
+  hidden: boolean;
+  title: string;
+  errors: (string | null | undefined)[];
+}>;
+export function usePrimaryPanelAction({
+  query,
+  proposePriceInput,
+}: {
+  query?: OracleQueryUI;
+  proposePriceInput?: string;
+}): ActionState | undefined {
+  // these are in order of importance
+  const accountAction = useAccountAction({ query });
+  const approveBondAction = useApproveBondAction({ query });
+  const proposeAction = useProposeAction({ query, proposePriceInput });
+  const disputeAction = useDisputeAction({ query });
+  const disputeAssertionAction = useDisputeAssertionAction({ query });
+  // TODO: work out settle logic. need to clarify how we can detect when to show settle, and interactions
+  // between change chain action, settle action and showing settled when on wrong chain
+  // const settlePriceAction = useSettlePriceAction({ query });
+  // const settleAssertionAction = useSettleAssertionAction({ query });
 
+  return (
+    accountAction ||
+    approveBondAction ||
+    proposeAction ||
+    disputeAction ||
+    disputeAssertionAction
+  );
+}
+
+export function useAccountAction({
+  query,
+}: {
+  query?: OracleQueryUI;
+}): ActionState | undefined {
+  const { isConnected } = useAccount();
+  const { isLoading: isWalletLoading } = useConnect();
+  const { chain: connectedChain } = useNetwork();
+  const { chainId, actionType } = query ?? {};
+  const { switchNetwork, isLoading: isNetworkLoading } = useSwitchNetwork();
+  // do not display a button for settle queries
+  if (actionType !== "dispute" && actionType !== "propose") return undefined;
+
+  // users wallet is connecting
+  if (isWalletLoading) {
+    return {
+      title: "Connecting Wallet...",
+      disabled: true,
+    };
+  }
+
+  // change chains is loading
+  if (isNetworkLoading) {
+    return {
+      title: "Changing Chains...",
+      disabled: true,
+    };
+  }
+  // user is not connected.  we have to use a special button, so we are just gonna signal with title
+  // and hide this button until we are connected.
+  if (!isConnected) {
+    return {
+      title: "Connect wallet",
+      hidden: true,
+    };
+  }
+
+  // we dont know users connected chain yet, do not allow any actions
+  if (connectedChain === undefined) {
+    return {
+      hidden: true,
+    };
+  }
+  if (switchNetwork === undefined) return undefined;
+  // we cannot allow any transactions until user is on correct chain for current request
+  if (connectedChain.id !== chainId) {
+    return {
+      title: "Change Chain",
+      action: () => {
+        switchNetwork(chainId);
+      },
+    };
+  }
+  return undefined;
+}
+
+export function useApproveBondAction({
+  query,
+}: {
+  query?: OracleQueryUI;
+}): ActionState | undefined {
+  const { bond, tokenAddress, chainId, approveBondSpendParams, actionType } =
+    query ?? {};
+  const { allowance, balance } = useBalanceAndAllowance(query);
   const {
     config: approveBondSpendConfig,
     error: prepareApproveBondSpendError,
     isLoading: isPrepareApproveBondSpendLoading,
   } = usePrepareContractWrite(approveBondSpendParams);
   const {
+    write: approveBondSpend,
+    data: approveBondSpendTransaction,
+    error: approveBondSpendError,
+    isLoading: isApproveBondSpendLoading,
+  } = useContractWrite(approveBondSpendConfig);
+  const { isLoading: isApprovingBondSpend } = useWaitForTransaction({
+    hash: approveBondSpendTransaction?.hash,
+  });
+
+  // notify based on approval
+  useEffect(() => {
+    if (!approveBondSpendTransaction) return;
+    const currencyComponent = (
+      <Currency
+        value={bond}
+        chainId={chainId}
+        address={tokenAddress}
+        showIcon={false}
+      />
+    );
+    handleNotifications(approveBondSpendTransaction, {
+      pending: <>Approving {currencyComponent}</>,
+      success: <>Approved {currencyComponent}</>,
+      error: <>Failed to approve {currencyComponent}</>,
+    }).catch(console.error);
+  }, [approveBondSpendTransaction, bond, chainId, tokenAddress]);
+
+  if (actionType !== "propose" && actionType !== "dispute") return undefined;
+  if (balance && bond && balance.value?.lt(bond)) {
+    return {
+      title: "Insuffiicent balance",
+      disabled: true,
+    };
+  }
+  if (!approveBondSpendParams) return undefined;
+  const needsToApprove =
+    allowance !== undefined && bond !== undefined && allowance.lt(bond);
+  if (!needsToApprove) return undefined;
+
+  if (isPrepareApproveBondSpendLoading) {
+    return {
+      title: "Approve Spending",
+      disabled: true,
+    };
+  }
+  if (isApproveBondSpendLoading || isApprovingBondSpend) {
+    return {
+      title: "Approving Spending...",
+      disabled: true,
+    };
+  }
+
+  return {
+    title: "Approve Spending",
+    action: approveBondSpend,
+    errors: [
+      prepareApproveBondSpendError?.message,
+      approveBondSpendError?.message,
+    ],
+  };
+}
+
+export function useProposeAction({
+  query,
+  proposePriceInput,
+}: {
+  query?: OracleQueryUI;
+  proposePriceInput?: string;
+}): ActionState | undefined {
+  const { proposePriceParams } = query ?? {};
+  const {
     config: proposePriceConfig,
     error: prepareProposePriceError,
     isLoading: isPrepareProposePriceLoading,
   } = usePrepareContractWrite(proposePriceParams?.(proposePriceInput));
+  const {
+    write: proposePrice,
+    data: proposePriceTransaction,
+    error: proposePriceError,
+    isLoading: isProposePriceLoading,
+  } = useContractWrite(proposePriceConfig);
+  const { isLoading: isProposingPrice } = useWaitForTransaction({
+    hash: proposePriceTransaction?.hash,
+  });
+  // notify based on proposal tx
+  useEffect(() => {
+    if (!proposePriceTransaction) return;
+    handleNotifications(proposePriceTransaction, {
+      pending: <>Proposing price</>,
+      success: <>Proposed price</>,
+      error: <>Failed to propose price</>,
+    }).catch(console.error);
+  }, [proposePriceTransaction]);
+
+  if (proposePriceParams === undefined) return undefined;
+
+  // TODO validate input
+  if (proposePriceInput === undefined || proposePriceInput?.length === 0) {
+    return {
+      title: "Propose",
+      disabled: true,
+    };
+  }
+
+  if (isPrepareProposePriceLoading) {
+    return {
+      title: "Propose",
+      disabled: true,
+    };
+  }
+  if (isProposePriceLoading || isProposingPrice) {
+    return {
+      title: "Proposing...",
+      disabled: true,
+    };
+  }
+  return {
+    title: "Propose",
+    action: proposePrice,
+    errors: [prepareProposePriceError?.message, proposePriceError?.message],
+  };
+}
+
+export function useDisputeAction({
+  query,
+}: {
+  query?: OracleQueryUI;
+}): ActionState | undefined {
+  const { disputePriceParams } = query ?? {};
   const {
     config: disputePriceConfig,
     error: prepareDisputePriceError,
     isLoading: isPrepareDisputePriceLoading,
   } = usePrepareContractWrite(disputePriceParams);
   const {
-    config: settlePriceConfig,
-    error: prepareSettlePriceError,
-    isLoading: isPrepareSettlePriceLoading,
-  } = usePrepareContractWrite(settlePriceParams);
+    write: disputePrice,
+    data: disputePriceTransaction,
+    error: disputePriceError,
+    isLoading: isDisputePriceLoading,
+  } = useContractWrite(disputePriceConfig);
+
+  const { isLoading: isDisputingPrice } = useWaitForTransaction({
+    hash: disputePriceTransaction?.hash,
+  });
+  // notify based on dispute tx
+  useEffect(() => {
+    if (!disputePriceTransaction) return;
+    handleNotifications(disputePriceTransaction, {
+      pending: <>Disputing price</>,
+      success: <>Disputed price</>,
+      error: <>Failed to dispute price</>,
+    }).catch(console.error);
+  }, [disputePriceTransaction]);
+
+  if (disputePriceParams === undefined) return undefined;
+
+  if (isPrepareDisputePriceLoading) {
+    return {
+      title: "Dispute",
+      disabled: true,
+    };
+  }
+  if (isDisputePriceLoading || isDisputingPrice) {
+    return {
+      title: "Disputing...",
+      disabled: true,
+    };
+  }
+  return {
+    title: "Dispute",
+    action: disputePrice,
+    errors: [prepareDisputePriceError?.message, disputePriceError?.message],
+  };
+}
+export function useDisputeAssertionAction({
+  query,
+}: {
+  query?: OracleQueryUI;
+}): ActionState | undefined {
+  const { disputeAssertionParams } = query ?? {};
+  const { address } = useAccount();
   const {
     config: disputeAssertionConfig,
     error: prepareDisputeAssertionError,
     isLoading: isPrepareDisputeAssertionLoading,
   } = usePrepareContractWrite(disputeAssertionParams?.(address));
   const {
-    config: settleAssertionConfig,
-    error: prepareSettleAssertionError,
-    isLoading: isPrepareSettleAssertionLoading,
-  } = usePrepareContractWrite(settleAssertionParams);
-
-  const {
-    writeAsync: approveBondSpend,
-    data: approveBondSpendTransaction,
-    error: approveBondSpendError,
-    isLoading: isApproveBondSpendLoading,
-  } = useContractWrite(approveBondSpendConfig);
-  const {
-    writeAsync: proposePrice,
-    data: proposePriceTransaction,
-    error: proposePriceError,
-    isLoading: isProposePriceLoading,
-  } = useContractWrite(proposePriceConfig);
-  const {
-    writeAsync: disputePrice,
-    data: disputePriceTransaction,
-    error: disputePriceError,
-    isLoading: isDisputePriceLoading,
-  } = useContractWrite(disputePriceConfig);
-  const {
-    writeAsync: settlePrice,
-    data: settlePriceTransaction,
-    error: settlePriceError,
-    isLoading: isSettlePriceLoading,
-  } = useContractWrite(settlePriceConfig);
-  const {
-    writeAsync: disputeAssertion,
+    write: disputeAssertion,
     data: disputeAssertionTransaction,
     error: disputeAssertionError,
     isLoading: isDisputeAssertionLoading,
   } = useContractWrite(disputeAssertionConfig);
+  const { isLoading: isDisputingAssertion } = useWaitForTransaction({
+    hash: disputeAssertionTransaction?.hash,
+  });
+
+  // notify based on dispute tx
+  useEffect(() => {
+    if (!disputeAssertionTransaction) return;
+    handleNotifications(disputeAssertionTransaction, {
+      pending: <>Disputing assertion</>,
+      success: <>Disputed assertion</>,
+      error: <>Failed to dispute assertion</>,
+    }).catch(console.error);
+  }, [disputeAssertionTransaction]);
+
+  if (disputeAssertionParams === undefined) return undefined;
+
+  if (isPrepareDisputeAssertionLoading) {
+    return {
+      title: "Dispute",
+      disabled: true,
+    };
+  }
+  if (isDisputeAssertionLoading || isDisputingAssertion) {
+    return {
+      title: "Disputing...",
+      disabled: true,
+    };
+  }
+  return {
+    title: "Dispute",
+    action: disputeAssertion,
+    errors: [
+      prepareDisputeAssertionError?.message,
+      disputeAssertionError?.message,
+    ],
+  };
+}
+
+export function useSettlePriceAction({
+  query,
+}: {
+  query?: OracleQueryUI;
+}): ActionState | undefined {
+  const { settlePriceParams } = query ?? {};
   const {
-    writeAsync: settleAssertion,
+    config: settlePriceConfig,
+    error: prepareSettlePriceError,
+    isLoading: isPrepareSettlePriceLoading,
+  } = usePrepareContractWrite(settlePriceParams);
+  const {
+    write: settlePrice,
+    data: settlePriceTransaction,
+    error: settlePriceError,
+    isLoading: isSettlePriceLoading,
+  } = useContractWrite(settlePriceConfig);
+  const { isLoading: isSettlingPrice } = useWaitForTransaction({
+    hash: settlePriceTransaction?.hash,
+  });
+  useEffect(() => {
+    if (!settlePriceTransaction) return;
+    handleNotifications(settlePriceTransaction, {
+      pending: <>Settling price</>,
+      success: <>Settled price</>,
+      error: <>Failed to settle price</>,
+    }).catch(console.error);
+  }, [settlePriceTransaction]);
+
+  if (settlePriceParams === undefined) return undefined;
+
+  if (isPrepareSettlePriceLoading) {
+    return {
+      title: "Settle",
+      disabled: true,
+    };
+  }
+  if (isSettlePriceLoading || isSettlingPrice) {
+    return {
+      title: "Settling...",
+      disabled: true,
+    };
+  }
+  // unique to settle, if we have an error preparing the transaction, this usually means the request has been settled
+  if (prepareSettlePriceError) {
+    return {
+      title: "Settled",
+      disabled: true,
+    };
+  }
+  return {
+    title: "Settle",
+    action: settlePrice,
+    errors: [settlePriceError?.message],
+  };
+}
+export function useSettleAssertionAction({
+  query,
+}: {
+  query?: OracleQueryUI;
+}): ActionState | undefined {
+  const { settleAssertionParams } = query ?? {};
+  const {
+    config: settleAssertionConfig,
+    error: prepareSettleAssertionError,
+    isLoading: isPrepareSettleAssertionLoading,
+  } = usePrepareContractWrite(settleAssertionParams);
+  const {
+    write: settleAssertion,
     data: settleAssertionTransaction,
     error: settleAssertionError,
     isLoading: isSettleAssertionLoading,
   } = useContractWrite(settleAssertionConfig);
-
-  const {
-    data: approveBondSpendReceipt,
-    isLoading: isApprovingBondSpend,
-    error: approvingBondSpendError,
-  } = useWaitForTransaction({
-    hash: approveBondSpendTransaction?.hash,
-  });
-  const {
-    data: proposePriceReceipt,
-    isLoading: isProposingPrice,
-    error: proposingPriceError,
-  } = useWaitForTransaction({
-    hash: proposePriceTransaction?.hash,
-  });
-  const {
-    data: disputePriceReceipt,
-    isLoading: isDisputingPrice,
-    error: disputingPriceError,
-  } = useWaitForTransaction({
-    hash: disputePriceTransaction?.hash,
-  });
-  const {
-    data: settlePriceReceipt,
-    isLoading: isSettlingPrice,
-    error: settlingPriceError,
-  } = useWaitForTransaction({
-    hash: settlePriceTransaction?.hash,
-  });
-  const {
-    data: disputeAssertionReceipt,
-    isLoading: isDisputingAssertion,
-    error: disputingAssertionError,
-  } = useWaitForTransaction({
-    hash: disputeAssertionTransaction?.hash,
-  });
-  const {
-    data: settleAssertionReceipt,
-    isLoading: isSettlingAssertion,
-    error: settlingAssertionError,
-  } = useWaitForTransaction({
+  const { isLoading: isSettlingAssertion } = useWaitForTransaction({
     hash: settleAssertionTransaction?.hash,
   });
-
-  const isPrepareLoading =
-    isPrepareApproveBondSpendLoading ||
-    isPrepareProposePriceLoading ||
-    isPrepareDisputePriceLoading ||
-    isPrepareSettlePriceLoading ||
-    isPrepareDisputeAssertionLoading ||
-    isPrepareSettleAssertionLoading;
-
-  const isActionLoading =
-    isPrepareLoading ||
-    isApproveBondSpendLoading ||
-    isProposePriceLoading ||
-    isDisputePriceLoading ||
-    isSettlePriceLoading ||
-    isDisputeAssertionLoading ||
-    isSettleAssertionLoading;
-
-  const isInteracting = Boolean(
-    isApprovingBondSpend ||
-      isProposingPrice ||
-      isDisputingPrice ||
-      isSettlingPrice ||
-      isDisputingAssertion ||
-      isSettlingAssertion
-  );
-
-  const isInteractionError = Boolean(
-    approvingBondSpendError ||
-      proposingPriceError ||
-      disputingPriceError ||
-      settlingPriceError ||
-      disputingAssertionError ||
-      settlingAssertionError
-  );
-
-  const isPrepareError = Boolean(
-    prepareApproveBondSpendError ||
-      prepareProposePriceError ||
-      prepareDisputePriceError ||
-      prepareSettlePriceError ||
-      prepareDisputeAssertionError ||
-      prepareSettleAssertionError
-  );
-
-  const isActionError = Boolean(
-    approveBondSpendError ||
-      proposePriceError ||
-      disputePriceError ||
-      settlePriceError ||
-      disputeAssertionError ||
-      settleAssertionError
-  );
-
-  const isLoading = isPrepareLoading || isActionLoading || isInteracting;
-  const isError = isPrepareError || isActionError || isInteractionError;
-
-  const errorMessages = [
-    ...new Set(
-      [
-        prepareApproveBondSpendError,
-        prepareProposePriceError,
-        prepareDisputePriceError,
-        prepareSettlePriceError,
-        prepareDisputeAssertionError,
-        prepareSettleAssertionError,
-        approveBondSpendError,
-        proposePriceError,
-        disputePriceError,
-        settlePriceError,
-        disputeAssertionError,
-        settleAssertionError,
-        approvingBondSpendError,
-        proposingPriceError,
-        disputingPriceError,
-        settlingPriceError,
-        disputingAssertionError,
-        settlingAssertionError,
-      ]
-        .filter(Boolean)
-        .map(({ message }) => message)
-    ),
-  ];
-
   useEffect(() => {
-    if (approveBondSpendTransaction) {
-      const currencyComponent = (
-        <Currency
-          value={query?.bond}
-          chainId={query?.chainId}
-          address={query?.tokenAddress}
-          showIcon={false}
-        />
-      );
-      void handleNotifications(approveBondSpendTransaction, {
-        pending: <>Approving {currencyComponent}</>,
-        success: <>Approved {currencyComponent}</>,
-        error: <>Failed to approve {currencyComponent}</>,
-      });
-    }
-    if (proposePriceTransaction) {
-      void handleNotifications(proposePriceTransaction, {
-        pending: <>Proposing price</>,
-        success: <>Proposed price</>,
-        error: <>Failed to propose price</>,
-      });
-    }
-    if (disputePriceTransaction) {
-      void handleNotifications(disputePriceTransaction, {
-        pending: <>Disputing price</>,
-        success: <>Disputed price</>,
-        error: <>Failed to dispute price</>,
-      });
-    }
-    if (settlePriceTransaction) {
-      void handleNotifications(settlePriceTransaction, {
-        pending: <>Settling price</>,
-        success: <>Settled price</>,
-        error: <>Failed to settle price</>,
-      });
-    }
-    if (disputeAssertionTransaction) {
-      void handleNotifications(disputeAssertionTransaction, {
-        pending: <>Disputing assertion</>,
-        success: <>Disputed assertion</>,
-        error: <>Failed to dispute assertion</>,
-      });
-    }
-    if (settleAssertionTransaction) {
-      void handleNotifications(settleAssertionTransaction, {
-        pending: <>Settling assertion</>,
-        success: <>Settled assertion</>,
-        error: <>Failed to settle assertion</>,
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    approveBondSpendTransaction,
-    proposePriceTransaction,
-    disputePriceTransaction,
-    settlePriceTransaction,
-    disputeAssertionTransaction,
-    settleAssertionTransaction,
-  ]);
+    if (!settleAssertionTransaction) return;
+    handleNotifications(settleAssertionTransaction, {
+      pending: <>Settling assertion</>,
+      success: <>Settled assertion</>,
+      error: <>Failed to settle assertion</>,
+    }).catch(console.error);
+  }, [settleAssertionTransaction]);
 
+  if (settleAssertionParams === undefined) return undefined;
+
+  if (isPrepareSettleAssertionLoading) {
+    return {
+      title: "Settle",
+      disabled: true,
+    };
+  }
+  if (isSettleAssertionLoading || isSettlingAssertion) {
+    return {
+      title: "Settling...",
+      disabled: true,
+    };
+  }
+  // unique to settle, if we have an error preparing the transaction, this usually means the request has been settled
+  if (prepareSettleAssertionError) {
+    return {
+      title: "Settled",
+      disabled: true,
+    };
+  }
   return {
-    approveBondSpend,
-    proposePrice,
-    disputePrice,
-    settlePrice,
-    disputeAssertion,
-    settleAssertion,
-    isLoading,
-    isPrepareLoading,
-    isActionLoading,
-    isInteracting,
-    isError,
-    isPrepareError,
-    isActionError,
-    isInteractionError,
-    errorMessages,
-    approveBondSpendReceipt,
-    proposePriceReceipt,
-    disputePriceReceipt,
-    settlePriceReceipt,
-    disputeAssertionReceipt,
-    settleAssertionReceipt,
+    title: "Settle",
+    action: settleAssertion,
+    errors: [settleAssertionError?.message],
   };
 }

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -38,10 +38,10 @@ export interface SolidityRequest {
 }
 
 export type ProposePriceParamsFactory = (
-  proposedPrice: string
+  proposedPrice?: string
 ) => ProposePriceParams | undefined;
 export type ProposePriceSkinnyParamsFactory = (
-  proposedPrice: string
+  proposedPrice?: string
 ) => ProposePriceSkinnyParams | undefined;
 export type DisputeAssertionParamsFactory = (
   disputerAddress: Address | undefined
@@ -84,16 +84,19 @@ export type OracleQueryUI = {
   expiryType: ExpiryType | null;
   oracleAddress: Address;
   tokenAddress: Address;
-  approveBondSpendParams: ApproveBondSpendParams | undefined;
-  proposePriceParams:
+  approveBondSpendParams?: ApproveBondSpendParams | undefined;
+  proposePriceParams?:
     | ProposePriceParamsFactory
     | ProposePriceSkinnyParamsFactory
     | undefined;
-  disputePriceParams: DisputePriceParams | DisputePriceSkinnyParams | undefined;
-  settlePriceParams: SettlePriceParams | SettlePriceSkinnyParams | undefined;
-  disputeAssertionParams: DisputeAssertionParamsFactory | undefined;
-  settleAssertionParams: SettleAssertionParams | undefined;
-
+  disputePriceParams?:
+    | DisputePriceParams
+    | DisputePriceSkinnyParams
+    | undefined;
+  settlePriceParams?: SettlePriceParams | SettlePriceSkinnyParams | undefined;
+  disputeAssertionParams?: DisputeAssertionParamsFactory | undefined;
+  settleAssertionParams?: SettleAssertionParams | undefined;
+  state?: string | undefined;
   // additional searchable properties, note these get parsed to strings even if bigint so we can compare with ==
   requestTimestamp?: string | null;
   requestHash?: string | null;


### PR DESCRIPTION
## motivation
The panel button was limited to just disputing/proposing/settling, etc, but we also need to connect and switch chains.

## changes
this refactors the actions hook to return a button state directly for rendering in the panel. this moves much of the business logic into the action hook and removes some from the panel itself. the button can now respond more dynamically to things like waiting on user, submitting transaction, checking user balance, approvals, etc, and adjust when its disabled, or what message is shown.

there are still issues with transactions showing errors in the panel, which will need to be fixed in new  prs. 

![image](https://user-images.githubusercontent.com/4429761/227580935-49f6cce8-23c9-4327-9beb-0313625f2858.png)
