### PR TITLE
fix: use correct timestamp for expiry

### DIFF
--- a/shared/utils/graphql.ts
+++ b/shared/utils/graphql.ts
@@ -131,6 +131,13 @@ export function parsePriceRequestGraphEntity(
     settlementHash,
     settlementLogIndex,
   } = priceRequest;
+
+  const now = Date.now();
+  let adjustedState = state;
+  if (state === "Proposed" && now > Number(proposalExpirationTimestamp)){
+    adjustedState = "Expired";
+  }
+
   const parsed: ParsedOOV1GraphEntity | ParsedOOV2GraphEntity = {
     chainId,
     oracleAddress,
@@ -159,7 +166,7 @@ export function parsePriceRequestGraphEntity(
       settlementRecipient,
     }),
     state:
-      (handleGraphqlNullableStringOrBytes({ state }) as RequestState) ??
+      (handleGraphqlNullableStringOrBytes({ state:adjustedState }) as RequestState) ??
       "Invalid",
     requestTimestamp: handleGraphqlNullableStringOrBytes({ requestTimestamp }),
     requestBlockNumber: handleGraphqlNullableBigIntToString({ requestBlockNumber }),

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -439,10 +439,11 @@ export function requestToOracleQuery(request: Request): OracleQueryUI {
     proposalTimestamp,
     proposalHash,
     proposalLogIndex,
+    proposalExpirationTimestamp,
   } = request;
-  const { bond, customLiveness, eventBased } = getOOV2SpecificValues(request);
+  const { bond, eventBased } = getOOV2SpecificValues(request);
   const bytes32Identifier = ethers.utils.formatBytes32String(identifier);
-  const livenessEndsMilliseconds = getLivenessEnds(customLiveness);
+  const livenessEndsMilliseconds = getLivenessEnds(proposalExpirationTimestamp);
   const formattedLivenessEndsIn = toTimeFormatted(livenessEndsMilliseconds);
   // TODO: we need methods to calculate these things
   // need a lookup for project based on price ident or anc data


### PR DESCRIPTION
## motivation
reloading page would reset expiry timestamp animation for some proposals and never show they ended

## changes
this looks at the correct expiry timestamp as reported by the graph. it also makes sure we go into a settleable state if we are past expiry, since the graph does not automatically update this information

these now correctly show expired:
![image](https://user-images.githubusercontent.com/4429761/227999302-018790f5-76bd-43aa-9467-baf49328bcaa.png)
