### PR TITLE
fix: switching between different tabs clears filters

### DIFF
--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -1,11 +1,7 @@
 import { hideOnMobileAndUnder, showOnMobileAndUnder } from "@/helpers";
-import type {
-  CheckboxItemsByFilterName,
-  CheckedFiltersByFilterName,
-  OnCheckedChange,
-} from "@/types";
+import { usePage } from "@/hooks";
+import type { PageName } from "@shared/types";
 import Sliders from "public/assets/icons/sliders.svg";
-import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 import styled from "styled-components";
 import { CheckedFilters } from "./CheckedFilters";
@@ -14,31 +10,15 @@ import { MobileFilters } from "./MobileFilters";
 import { Search } from "./Search";
 
 interface Props {
-  filters: CheckboxItemsByFilterName;
-  checkedFilters: CheckedFiltersByFilterName;
-  onCheckedChange: OnCheckedChange;
-  reset: () => void;
-  searchTerm: string;
-  setSearchTerm: Dispatch<SetStateAction<string>>;
+  page: PageName;
 }
-/**
- * Component for searching and filtering queries
- * @param filters The filters that are used to create the dropdown menus.
- * @param checkedFilters The checked filters
- * @param onCheckedChange A callback function that is called when a checkbox is checked or unchecked.
- * @param reset A callback function that is called when the "Clear filters" button is clicked
- * @param searchTerm The search term
- * @param setSearchTerm A callback function that is called when the search term is changed
- */
-export function Filters({
-  filters,
-  checkedFilters,
-  onCheckedChange,
-  reset,
-  searchTerm,
-  setSearchTerm,
-}: Props) {
+export function Filters({ page }: Props) {
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+
+  const {
+    filterProps: { filters, checkedFilters, onCheckedChange, reset },
+    searchProps: { searchTerm, setSearchTerm },
+  } = usePage(page);
 
   function openMobileFilters() {
     setMobileFiltersOpen(true);

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,10 @@
-import { ErrorBanner, Header, Notifications, Panel } from "@/components";
+import {
+  ErrorBanner,
+  Filters,
+  Header,
+  Notifications,
+  Panel,
+} from "@/components";
 import { siteDescription, siteTitle } from "@/constants";
 import { capitalizeFirstLetter, determinePage } from "@/helpers";
 import Head from "next/head";
@@ -22,6 +28,7 @@ export function Layout({ children }: { children: ReactNode }) {
       <Main>
         <ErrorBanner />
         <Header page={page} />
+        <Filters page={page} />
         {children}
         <Panel />
         <Notifications />

--- a/src/components/OracleQueries.tsx
+++ b/src/components/OracleQueries.tsx
@@ -1,22 +1,15 @@
 import { OracleQueryList, OracleQueryTable } from "@/components";
 import { hideOnMobileAndUnder, showOnMobileAndUnder } from "@/helpers";
-import type { OracleQueryUI } from "@/types";
+import { usePage } from "@/hooks";
 import type { PageName } from "@shared/types";
 import styled from "styled-components";
 
 interface Props {
   page: PageName;
-  queries: OracleQueryUI[];
-  isLoading: boolean;
 }
-/**
- * Renders a list or a table of oracle queries.
- * Shows a list on mobile and a table on desktop.
- * @param page The page the queries are being rendered on.
- * @param queries The queries to render.
- * @param isLoading Whether the queries are still loading.
- */
-export function OracleQueries({ page, queries, isLoading }: Props) {
+
+export function OracleQueries({ page }: Props) {
+  const { results: queries, isLoading } = usePage(page);
   return (
     <>
       <DesktopWrapper>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,16 +1,16 @@
-import { GlobalStyle } from "@/components";
+import { GlobalStyle, Layout } from "@/components";
 import {
+  chains as supportedChains,
   config,
   red500,
-  chains as supportedChains,
   walletsAndConnectors,
   white,
 } from "@/constants";
 import {
   ErrorProvider,
+  NotificationsProvider,
   OracleDataProvider,
   PanelProvider,
-  NotificationsProvider,
 } from "@/contexts";
 import "@/styles/fonts.css";
 import { darkTheme, RainbowKitProvider } from "@rainbow-me/rainbowkit";
@@ -48,8 +48,10 @@ export default function App({ Component, pageProps }: AppProps) {
           <OracleDataProvider>
             <ErrorProvider>
               <PanelProvider>
-                <GlobalStyle />
-                <Component {...pageProps} />
+                <Layout>
+                  <GlobalStyle />
+                  <Component {...pageProps} />
+                </Layout>
               </PanelProvider>
             </ErrorProvider>
           </OracleDataProvider>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,16 +1,5 @@
-import { Filters, Layout, OracleQueries } from "@/components";
-import { usePage } from "@/hooks";
+import { OracleQueries } from "@/components";
 
 export default function Verify() {
-  const page = usePage("verify");
-  return (
-    <Layout>
-      <Filters {...page.filterProps} {...page.searchProps} />
-      <OracleQueries
-        queries={page.results}
-        isLoading={page.isLoading}
-        page={page.name}
-      />
-    </Layout>
-  );
+  return <OracleQueries page="verify" />;
 }

--- a/src/pages/propose.tsx
+++ b/src/pages/propose.tsx
@@ -1,16 +1,5 @@
-import { Filters, Layout, OracleQueries } from "@/components";
-import { usePage } from "@/hooks";
+import { OracleQueries } from "@/components";
 
 export default function Propose() {
-  const page = usePage("propose");
-  return (
-    <Layout>
-      <Filters {...page.filterProps} {...page.searchProps} />
-      <OracleQueries
-        queries={page.results}
-        isLoading={page.isLoading}
-        page={page.name}
-      />
-    </Layout>
-  );
+  return <OracleQueries page="propose" />;
 }

--- a/src/pages/settled.tsx
+++ b/src/pages/settled.tsx
@@ -1,16 +1,5 @@
-import { Filters, Layout, OracleQueries } from "@/components";
-import { usePage } from "@/hooks";
+import { OracleQueries } from "@/components";
 
 export default function Settled() {
-  const page = usePage("settled");
-  return (
-    <Layout>
-      <Filters {...page.filterProps} {...page.searchProps} />
-      <OracleQueries
-        queries={page.results}
-        isLoading={page.isLoading}
-        page={page.name}
-      />
-    </Layout>
-  );
+  return <OracleQueries page="settled" />;
 }

--- a/src/stories/Filters.stories.tsx
+++ b/src/stories/Filters.stories.tsx
@@ -12,13 +12,11 @@ export default meta;
 type Story = StoryObj<typeof Filters>;
 
 function Wrapper() {
-  const { results, searchProps, filterProps } = useFilterAndSearch(
-    verifyMockOracleQueryUIs()
-  );
+  const { results } = useFilterAndSearch(verifyMockOracleQueryUIs());
 
   return (
     <div>
-      <Filters {...filterProps} {...searchProps} />
+      <Filters page="propose" />
       <div>{JSON.stringify(results)}</div>
     </div>
   );

--- a/src/stories/OracleQueries.stories.tsx
+++ b/src/stories/OracleQueries.stories.tsx
@@ -1,13 +1,6 @@
 import { OracleQueries, Panel } from "@/components";
 import { PanelProvider } from "@/contexts";
 import type { Meta, StoryObj } from "@storybook/react";
-import {
-  makeMockOracleQueryUIs,
-  makeRandomTitle,
-  proposeMockOracleQueryUIs,
-  settledMockOracleQueryUIs,
-  verifyMockOracleQueryUIs,
-} from "./mocks";
 
 const meta: Meta<typeof OracleQueries> = {
   component: OracleQueries,
@@ -28,56 +21,41 @@ type Story = StoryObj<typeof OracleQueries>;
 export const Propose: Story = {
   args: {
     page: "propose",
-    queries: proposeMockOracleQueryUIs(),
   },
 };
 
 export const Verify: Story = {
   args: {
     page: "verify",
-    queries: verifyMockOracleQueryUIs(),
   },
 };
 
 export const Settled: Story = {
   args: {
     page: "settled",
-    queries: settledMockOracleQueryUIs(),
   },
 };
 
 export const WithPagination: Story = {
   args: {
     page: "propose",
-    queries: makeMockOracleQueryUIs({
-      count: 100,
-      inputs: Array.from({ length: 100 }, () => ({
-        title: makeRandomTitle(),
-      })),
-    }),
   },
 };
 
 export const ProposeLoading: Story = {
   args: {
     page: "propose",
-    queries: [],
-    isLoading: true,
   },
 };
 
 export const VerifyLoading: Story = {
   args: {
     page: "verify",
-    queries: [],
-    isLoading: true,
   },
 };
 
 export const SettledLoading: Story = {
   args: {
     page: "settled",
-    queries: [],
-    isLoading: true,
   },
 };


### PR DESCRIPTION
### Motivation

We want to persist the filter selection on different pages.

### Changes

* Move filters component to shared layout which is preserved on page changes
* Get the props needed for filters and queries with the page hook