### PR TITLE
fix: wrong entries and double counting in filters

### DIFF
--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -1,6 +1,5 @@
 import { hideOnMobileAndUnder, showOnMobileAndUnder } from "@/helpers";
-import { usePage } from "@/hooks";
-import type { PageName } from "@shared/types";
+import { useFilterAndSearchContext } from "@/hooks";
 import Sliders from "public/assets/icons/sliders.svg";
 import { useState } from "react";
 import styled from "styled-components";
@@ -9,16 +8,17 @@ import { Dropdowns } from "./Dropdowns";
 import { MobileFilters } from "./MobileFilters";
 import { Search } from "./Search";
 
-interface Props {
-  page: PageName;
-}
-export function Filters({ page }: Props) {
+export function Filters() {
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
   const {
-    filterProps: { filters, checkedFilters, onCheckedChange, reset },
-    searchProps: { searchTerm, setSearchTerm },
-  } = usePage(page);
+    filters,
+    checkedFilters,
+    onCheckedChange,
+    reset,
+    searchTerm,
+    setSearchTerm,
+  } = useFilterAndSearchContext();
 
   function openMobileFilters() {
     setMobileFiltersOpen(true);

--- a/src/components/Filters/Search.tsx
+++ b/src/components/Filters/Search.tsx
@@ -1,10 +1,10 @@
 import SearchIcon from "public/assets/icons/search.svg";
-import type { Dispatch, FormEvent, SetStateAction } from "react";
+import type { FormEvent } from "react";
 import styled from "styled-components";
 
 interface Props {
   searchTerm: string;
-  setSearchTerm: Dispatch<SetStateAction<string>>;
+  setSearchTerm: (searchTerm: string) => void;
 }
 /**
  * Component for searching queries

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,16 +6,15 @@ import {
   Panel,
 } from "@/components";
 import { siteDescription, siteTitle } from "@/constants";
-import { capitalizeFirstLetter, determinePage } from "@/helpers";
+import { capitalizeFirstLetter } from "@/helpers";
+import { useHandleQueryInUrl, usePageContext } from "@/hooks";
 import Head from "next/head";
-import { useRouter } from "next/router";
 import type { ReactNode } from "react";
 import styled from "styled-components";
 
 export function Layout({ children }: { children: ReactNode }) {
-  const router = useRouter();
-  const pathname = router?.pathname;
-  const page = determinePage(pathname);
+  const { page } = usePageContext();
+  useHandleQueryInUrl();
 
   return (
     <>
@@ -28,7 +27,7 @@ export function Layout({ children }: { children: ReactNode }) {
       <Main>
         <ErrorBanner />
         <Header page={page} />
-        <Filters page={page} />
+        <Filters />
         {children}
         <Panel />
         <Notifications />

--- a/src/components/OracleQueries.tsx
+++ b/src/components/OracleQueries.tsx
@@ -1,15 +1,31 @@
 import { OracleQueryList, OracleQueryTable } from "@/components";
 import { hideOnMobileAndUnder, showOnMobileAndUnder } from "@/helpers";
-import { usePage } from "@/hooks";
+import { useFilterAndSearchContext } from "@/hooks";
 import type { PageName } from "@shared/types";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
+import { useTimeout } from "usehooks-ts";
 
 interface Props {
   page: PageName;
 }
 
 export function OracleQueries({ page }: Props) {
-  const { results: queries, isLoading } = usePage(page);
+  const { results: queries } = useFilterAndSearchContext();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (queries.length > 0) {
+      setIsLoading(false);
+    }
+  }, [queries]);
+
+  useTimeout(() => {
+    if (queries !== undefined) {
+      setIsLoading(false);
+    }
+  }, 3000);
+
   return (
     <>
       <DesktopWrapper>

--- a/src/constants/filters.ts
+++ b/src/constants/filters.ts
@@ -29,3 +29,15 @@ export const keys = [
   "proposalHash",
   "proposalLogIndex",
 ];
+
+export const emptyFilters = {
+  project: { All: { checked: true, count: 0 } },
+  chainName: { All: { checked: true, count: 0 } },
+  oracleType: { All: { checked: true, count: 0 } },
+};
+
+export const emptyCheckedFilters = {
+  project: [],
+  chainName: [],
+  oracleType: [],
+};

--- a/src/contexts/FilterAndSearchContext.tsx
+++ b/src/contexts/FilterAndSearchContext.tsx
@@ -1,13 +1,11 @@
 import { emptyCheckedFilters, emptyFilters } from "@/constants";
-import { determinePage } from "@/helpers";
-import { useFilterAndSearch, useOracleDataContext } from "@/hooks";
+import { useFilterAndSearch, useQueriesCurrentForPage } from "@/hooks";
 import type {
   CheckboxItemsByFilterName,
   CheckedChangePayload,
   CheckedFiltersByFilterName,
   OracleQueryUI,
 } from "@/types";
-import { useRouter } from "next/router";
 import type { ReactNode } from "react";
 import { createContext } from "react";
 
@@ -40,18 +38,7 @@ export const FilterAndSearchContext = createContext(
 );
 
 export function FilterAndSearchProvider({ children }: { children: ReactNode }) {
-  const { settled, propose, verify } = useOracleDataContext();
-  const router = useRouter();
-  const pathname = router.pathname;
-  const page = determinePage(pathname);
-  const queries =
-    page === "verify"
-      ? verify
-      : page === "propose"
-      ? propose
-      : page === "settled"
-      ? settled
-      : undefined;
+  const queries = useQueriesCurrentForPage();
   const filterAndSearchState = useFilterAndSearch(queries);
 
   return (

--- a/src/contexts/FilterAndSearchContext.tsx
+++ b/src/contexts/FilterAndSearchContext.tsx
@@ -1,0 +1,62 @@
+import { emptyCheckedFilters, emptyFilters } from "@/constants";
+import { determinePage } from "@/helpers";
+import { useFilterAndSearch, useOracleDataContext } from "@/hooks";
+import type {
+  CheckboxItemsByFilterName,
+  CheckedChangePayload,
+  CheckedFiltersByFilterName,
+  OracleQueryUI,
+} from "@/types";
+import { useRouter } from "next/router";
+import type { ReactNode } from "react";
+import { createContext } from "react";
+
+export interface FilterAndSearchContextState {
+  results: OracleQueryUI[];
+  searchTerm: string;
+  setSearchTerm: (searchTerm: string) => void;
+  filters: CheckboxItemsByFilterName;
+  checkedFilters: CheckedFiltersByFilterName;
+  onCheckedChange: (payload: CheckedChangePayload) => void;
+  reset: () => void;
+}
+
+export const defaultFilterAndSearchContextState: FilterAndSearchContextState = {
+  results: [],
+  searchTerm: "",
+  setSearchTerm: () => null,
+  filters: {
+    ...emptyFilters,
+  },
+  checkedFilters: {
+    ...emptyCheckedFilters,
+  },
+  onCheckedChange: () => null,
+  reset: () => null,
+};
+
+export const FilterAndSearchContext = createContext(
+  defaultFilterAndSearchContextState
+);
+
+export function FilterAndSearchProvider({ children }: { children: ReactNode }) {
+  const { settled, propose, verify } = useOracleDataContext();
+  const router = useRouter();
+  const pathname = router.pathname;
+  const page = determinePage(pathname);
+  const queries =
+    page === "verify"
+      ? verify
+      : page === "propose"
+      ? propose
+      : page === "settled"
+      ? settled
+      : undefined;
+  const filterAndSearchState = useFilterAndSearch(queries);
+
+  return (
+    <FilterAndSearchContext.Provider value={filterAndSearchState}>
+      {children}
+    </FilterAndSearchContext.Provider>
+  );
+}

--- a/src/contexts/PageContext.tsx
+++ b/src/contexts/PageContext.tsx
@@ -1,0 +1,25 @@
+import type { PageName } from "@shared/types";
+import type { ReactNode } from "react";
+import { createContext, useState } from "react";
+
+export interface PageContextState {
+  page: PageName;
+  setPage: (page: PageName) => void;
+}
+
+export const defaultState: PageContextState = {
+  page: "verify",
+  setPage: () => null,
+};
+
+export const PageContext = createContext(defaultState);
+
+export function PageProvider({ children }: { children: ReactNode }) {
+  const [page, setPage] = useState<PageName>("verify");
+
+  return (
+    <PageContext.Provider value={{ page, setPage }}>
+      {children}
+    </PageContext.Provider>
+  );
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -2,4 +2,5 @@ export * from "./ErrorContext";
 export * from "./FilterAndSearchContext";
 export * from "./NotificationsContext";
 export * from "./OracleDataContext";
+export * from "./PageContext";
 export * from "./PanelContext";

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,4 +1,5 @@
 export * from "./ErrorContext";
+export * from "./FilterAndSearchContext";
+export * from "./NotificationsContext";
 export * from "./OracleDataContext";
 export * from "./PanelContext";
-export * from "./NotificationsContext";

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -39,12 +39,6 @@ export function capitalizeFirstLetter(str: string | undefined | null) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-export function determinePage(pathname: string) {
-  if (pathname === "/propose") return "propose";
-  if (pathname === "/settled") return "settled";
-  return "verify";
-}
-
 /**
  * Determines if a route is active.
  * @param pathname - the current pathname

--- a/src/hooks/contexts.ts
+++ b/src/hooks/contexts.ts
@@ -1,8 +1,9 @@
 import {
   ErrorContext,
-  PanelContext,
-  OracleDataContext,
+  FilterAndSearchContext,
   NotificationsContext,
+  OracleDataContext,
+  PanelContext,
 } from "@/contexts";
 import { useContext } from "react";
 
@@ -10,3 +11,5 @@ export const usePanelContext = () => useContext(PanelContext);
 export const useErrorContext = () => useContext(ErrorContext);
 export const useOracleDataContext = () => useContext(OracleDataContext);
 export const useNotificationsContext = () => useContext(NotificationsContext);
+export const useFilterAndSearchContext = () =>
+  useContext(FilterAndSearchContext);

--- a/src/hooks/contexts.ts
+++ b/src/hooks/contexts.ts
@@ -3,6 +3,7 @@ import {
   FilterAndSearchContext,
   NotificationsContext,
   OracleDataContext,
+  PageContext,
   PanelContext,
 } from "@/contexts";
 import { useContext } from "react";
@@ -13,3 +14,4 @@ export const useOracleDataContext = () => useContext(OracleDataContext);
 export const useNotificationsContext = () => useContext(NotificationsContext);
 export const useFilterAndSearchContext = () =>
   useContext(FilterAndSearchContext);
+export const usePageContext = () => useContext(PageContext);

--- a/src/hooks/handleQueryInUrl.ts
+++ b/src/hooks/handleQueryInUrl.ts
@@ -1,0 +1,28 @@
+import {
+  usePageContext,
+  usePanelContext,
+  useQueriesCurrentForPage,
+} from "@/hooks";
+import type { OracleQueryUI } from "@/types";
+import filter from "lodash/filter";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+export function useHandleQueryInUrl() {
+  const router = useRouter();
+  const { openPanel, panelOpen } = usePanelContext();
+  const { page } = usePageContext();
+  const queries = useQueriesCurrentForPage();
+
+  useEffect(() => {
+    const hasQueryUrl = Object.keys(router.query).length > 0;
+    const queryResults: OracleQueryUI[] = filter<OracleQueryUI>(
+      queries,
+      router.query
+    );
+    if (hasQueryUrl && queryResults.length === 1 && !panelOpen) {
+      openPanel(queryResults[0], page, false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.query, queries]);
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,6 +2,8 @@ export * from "./actions";
 export * from "./balanceAndAllowance";
 export * from "./contexts";
 export * from "./filters";
+export * from "./handleQueryInUrl";
 export * from "./helpers";
 export * from "./page";
 export * from "./queries";
+export * from "./queriesForCurrentPage";

--- a/src/hooks/page.ts
+++ b/src/hooks/page.ts
@@ -1,51 +1,12 @@
-import {
-  useFilterAndSearch,
-  useOracleDataContext,
-  usePanelContext,
-} from "@/hooks";
-import type { OracleQueryUI } from "@/types";
 import type { PageName } from "@shared/types";
-import filter from "lodash/filter";
-import { useRouter } from "next/router";
 import { useEffect } from "react";
+import { usePageContext } from "./contexts";
 
-type FilterState = ReturnType<typeof useFilterAndSearch>;
-type PageState = FilterState & {
-  name: PageName;
-  isLoading: boolean;
-};
-export function usePage(name: PageName): PageState {
-  const { settled, propose, verify } = useOracleDataContext();
-  const router = useRouter();
-  const { openPanel, panelOpen } = usePanelContext();
-  const queries =
-    name === "verify"
-      ? verify
-      : name === "propose"
-      ? propose
-      : name === "settled"
-      ? settled
-      : undefined;
-  const filterAndSearch = useFilterAndSearch(queries);
-  const isLoading = queries === undefined;
-  // this is what drives opening and closing panels based on router,
-  // there should only be one place that watches the url query params for changes
-  // currently this is in the use page component
+export function usePage(page: PageName) {
+  const { setPage } = usePageContext();
+
   useEffect(() => {
-    const hasQueryUrl = Object.keys(router.query).length > 0;
-    const queryResults: OracleQueryUI[] = filter<OracleQueryUI>(
-      queries,
-      router.query
-    );
-    if (hasQueryUrl && queryResults.length === 1 && !panelOpen) {
-      openPanel(queryResults[0], name, false);
-    }
+    setPage(page);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.query, queries]);
-
-  return {
-    name,
-    isLoading,
-    ...filterAndSearch,
-  };
+  }, []);
 }

--- a/src/hooks/queriesForCurrentPage.ts
+++ b/src/hooks/queriesForCurrentPage.ts
@@ -1,0 +1,9 @@
+import { useOracleDataContext, usePageContext } from "./contexts";
+
+export function useQueriesCurrentForPage() {
+  const { page } = usePageContext();
+  const queries = useOracleDataContext();
+  const queriesForPage = queries[page];
+
+  return queriesForPage;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,8 +8,10 @@ import {
 } from "@/constants";
 import {
   ErrorProvider,
+  FilterAndSearchProvider,
   NotificationsProvider,
   OracleDataProvider,
+  PageProvider,
   PanelProvider,
 } from "@/contexts";
 import "@/styles/fonts.css";
@@ -44,18 +46,22 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <WagmiConfig client={wagmiClient}>
       <RainbowKitProvider chains={chains} theme={rainbowKitTheme}>
-        <NotificationsProvider>
-          <OracleDataProvider>
-            <ErrorProvider>
-              <PanelProvider>
-                <Layout>
-                  <GlobalStyle />
-                  <Component {...pageProps} />
-                </Layout>
-              </PanelProvider>
-            </ErrorProvider>
-          </OracleDataProvider>
-        </NotificationsProvider>
+        <PageProvider>
+          <NotificationsProvider>
+            <OracleDataProvider>
+              <ErrorProvider>
+                <PanelProvider>
+                  <FilterAndSearchProvider>
+                    <Layout>
+                      <GlobalStyle />
+                      <Component {...pageProps} />
+                    </Layout>
+                  </FilterAndSearchProvider>
+                </PanelProvider>
+              </ErrorProvider>
+            </OracleDataProvider>
+          </NotificationsProvider>
+        </PageProvider>
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,8 @@
 import { OracleQueries } from "@/components";
+import { usePage } from "@/hooks";
 
 export default function Verify() {
-  return <OracleQueries page="verify" />;
+  const page = "verify";
+  usePage(page);
+  return <OracleQueries page={page} />;
 }

--- a/src/pages/propose.tsx
+++ b/src/pages/propose.tsx
@@ -1,5 +1,8 @@
 import { OracleQueries } from "@/components";
+import { usePage } from "@/hooks";
 
 export default function Propose() {
-  return <OracleQueries page="propose" />;
+  const page = "propose";
+  usePage(page);
+  return <OracleQueries page={page} />;
 }

--- a/src/pages/settled.tsx
+++ b/src/pages/settled.tsx
@@ -1,5 +1,8 @@
 import { OracleQueries } from "@/components";
+import { usePage } from "@/hooks";
 
 export default function Settled() {
-  return <OracleQueries page="settled" />;
+  const page = "settled";
+  usePage(page);
+  return <OracleQueries page={page} />;
 }

--- a/src/stories/Filters.stories.tsx
+++ b/src/stories/Filters.stories.tsx
@@ -16,7 +16,7 @@ function Wrapper() {
 
   return (
     <div>
-      <Filters page="propose" />
+      <Filters />
       <div>{JSON.stringify(results)}</div>
     </div>
   );

--- a/src/stories/pages/shared.tsx
+++ b/src/stories/pages/shared.tsx
@@ -1,9 +1,11 @@
 import { Layout } from "@/components";
 import {
   ErrorProvider,
+  FilterAndSearchProvider,
   NotificationsContext,
   NotificationsProvider,
   OracleDataProvider,
+  PageProvider,
   PanelProvider,
 } from "@/contexts";
 import type { UniqueId } from "@/types";
@@ -16,17 +18,21 @@ interface Props {
 }
 export function Wrapper({ Component }: Props) {
   return (
-    <NotificationsProvider>
-      <OracleDataProvider>
-        <ErrorProvider>
-          <PanelProvider>
-            <Layout>
-              <Component />
-            </Layout>
-          </PanelProvider>
-        </ErrorProvider>
-      </OracleDataProvider>
-    </NotificationsProvider>
+    <PageProvider>
+      <NotificationsProvider>
+        <OracleDataProvider>
+          <ErrorProvider>
+            <FilterAndSearchProvider>
+              <PanelProvider>
+                <Layout>
+                  <Component />
+                </Layout>
+              </PanelProvider>
+            </FilterAndSearchProvider>
+          </ErrorProvider>
+        </OracleDataProvider>
+      </NotificationsProvider>
+    </PageProvider>
   );
 }
 


### PR DESCRIPTION
### Motivation

There are some bugs in the filtering logic now that we're sharing them across pages. These come about mostly because we are storing the filtering data in a hook, which is being invoked multiple times on different pages. This is solved by lifting this state up into a context and providing that state in the hook instead. The hook can then be invoked wherever.

Another difficulty was passing the page we're on to the filters and making sure that the filters are operating on the right queries. This is solved by removing lifting this state up in a context as well. Now pages explicitly set the "page" value when they are navigated to, and the dependency on the url is removed (helpful for future tasks too).

Finally, the counting logic in the filters was wrong and lead to double counting of entries on renders. This has been fixed with a solution that is also more efficient.

### Changes

* Add `FilterAndSearchContext` for holding filter and search state
* Add `PageContext` for holding which page we are on
* Add hook to get queries for the current page
* Fix entry counting bug in filters