### PR TITLE
feat: sort queries by date

### DIFF
--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -1,5 +1,9 @@
 import { config } from "@/constants";
-import { assertionToOracleQuery, requestToOracleQuery } from "@/helpers";
+import {
+  assertionToOracleQuery,
+  requestToOracleQuery,
+  sortQueriesByDate,
+} from "@/helpers";
 import type { OracleQueryUI } from "@/types";
 import { Client } from "@libs/oracle2";
 import { oracles } from "@libs/oracle2/services";
@@ -86,10 +90,11 @@ function DataReducerFactory<Input extends Request | Assertion>(
     return {
       ...state,
       all: { ...all },
-      ...queries,
+      ...sortQueriesByDate(queries),
     };
   };
 }
+
 const requestReducer = DataReducerFactory(requestToOracleQuery);
 const assertionReducer = DataReducerFactory(assertionToOracleQuery);
 

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,4 +1,5 @@
 import { mobileAndUnder, tabletAndUnder } from "@/constants";
+import type { OracleQueryList } from "@/contexts";
 import { capitalize, words } from "lodash";
 import { css } from "styled-components";
 
@@ -99,4 +100,20 @@ export const showOnMobileAndUnder = css`
 
 export function makeFilterTitle(filterName: string) {
   return capitalize(words(filterName)[0]);
+}
+
+export function sortQueriesByDate({
+  verify,
+  propose,
+  settled,
+}: {
+  verify: OracleQueryList;
+  propose: OracleQueryList;
+  settled: OracleQueryList;
+}) {
+  return {
+    verify: verify.sort((a, b) => b.timeMilliseconds - a.timeMilliseconds),
+    propose: propose.sort((a, b) => b.timeMilliseconds - a.timeMilliseconds),
+    settled: settled.sort((a, b) => b.timeMilliseconds - a.timeMilliseconds),
+  };
 }


### PR DESCRIPTION
### Motivation

We want the queries on each page to be sorted by date.

### Changes

* Add sort by date util
* Sort `verify`, `propose`, and `settled` queries by date whenever we add new queries to the list