### PR TITLE
feat: update oracle data from transaction receipts

### DIFF
--- a/libs/src/clients/optimisticOracle/client.ts
+++ b/libs/src/clients/optimisticOracle/client.ts
@@ -67,6 +67,10 @@ export type Request = RequestKey &
     proposeBlockNumber: number;
     disputeBlockNumber: number;
     settleBlockNumber: number;
+    requestLogIndex: number;
+    proposeLogIndex: number;
+    disputeLogIndex: number;
+    settleLogIndex: number;
   }>;
 
 export interface EventState {
@@ -76,13 +80,12 @@ export interface EventState {
 export function requestId(
   request: Omit<RequestKey, "timestamp"> & { timestamp: BigNumberish }
 ): string {
-  // if enabling sorting, put timestamp first
+  // this matches how we generate ids in the subgraph
   return [
-    request.timestamp.toString(),
     request.identifier,
-    request.requester,
+    request.timestamp.toString(),
     request.ancillaryData,
-  ].join("!");
+  ].join("-");
 }
 
 export function reduceEvents(state: EventState, event: Event): EventState {
@@ -114,6 +117,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Requested,
         requestTx: event.transactionHash,
         requestBlockNumber: event.blockNumber,
+        requestLogIndex: event.logIndex,
       };
       break;
     }
@@ -146,6 +150,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Proposed,
         proposeTx: event.transactionHash,
         proposeBlockNumber: event.blockNumber,
+        proposeLogIndex: event.logIndex,
       };
       break;
     }
@@ -176,6 +181,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Disputed,
         disputeTx: event.transactionHash,
         disputeBlockNumber: event.blockNumber,
+        disputeLogIndex: event.logIndex,
       };
       break;
     }
@@ -209,6 +215,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Settled,
         settleTx: event.transactionHash,
         settleBlockNumber: event.blockNumber,
+        settleLogIndex: event.logIndex,
       };
       break;
     }

--- a/libs/src/oracle-sdk-v2/client.ts
+++ b/libs/src/oracle-sdk-v2/client.ts
@@ -8,7 +8,7 @@ export function Client(factories: ServiceFactories, handlers: Handlers) {
   const services = factories.map((factory) => factory(handlers));
   async function tick() {
     const results = await Promise.allSettled(
-      services.map((service) => service.tick())
+      services.map((service) => (service ? service.tick() : undefined))
     );
     const errors: (Error | undefined)[] = results.map((result) => {
       if (isRejected(result)) {

--- a/libs/src/oracle-sdk-v2/services/index.ts
+++ b/libs/src/oracle-sdk-v2/services/index.ts
@@ -1,4 +1,5 @@
 export * as oracle1Gql from "./oraclev1/gql";
+export * as oracle1Ethers from "./oraclev1/ethers";
 // oracle 2 is handled the same way as oracle 1
 export * as oracle2Gql from "./oraclev1/gql";
 // oracle skinny is same as oracle 1

--- a/libs/src/oracle-sdk-v2/services/oracles/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oracles/factory.ts
@@ -35,7 +35,9 @@ export const Factory =
     });
 
     async function tick() {
-      await Promise.all(services.map(async (service) => service.tick()));
+      await Promise.all(
+        services.map(async (service) => (service ? service.tick() : undefined))
+      );
     }
 
     return {

--- a/libs/src/oracle-sdk-v2/services/oraclev1/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/ethers/factory.ts
@@ -1,0 +1,152 @@
+import Events from "events";
+import { ethers } from "ethers";
+import { assertAddress } from "@shared/utils";
+import type {
+  Request as SharedRequest,
+  OracleType,
+  ChainId,
+  RequestState as SharedRequestState,
+} from "@shared/types";
+import type { Address } from "wagmi";
+import type {
+  Handlers,
+  Service,
+  ServiceFactory,
+} from "@libs/oracle-sdk-v2/types";
+import type { TransactionReceipt } from "@libs/types";
+import type { Request } from "@libs/clients/optimisticOracle";
+import { RequestState, requestId } from "@libs/clients/optimisticOracle";
+import { OptimisticOracle } from "@libs/oracle-sdk-v1/services/optimisticOracle";
+
+export type Config = {
+  chainId: ChainId;
+  url: string;
+  address: string;
+};
+
+function convertToSharedState(state: RequestState): SharedRequestState {
+  if (state === RequestState.Invalid) return "Invalid";
+  if (state === RequestState.Requested) return "Requested";
+  if (state === RequestState.Proposed) return "Proposed";
+  if (state === RequestState.Expired) return "Expired";
+  if (state === RequestState.Disputed) return "Disputed";
+  if (state === RequestState.Resolved) return "Resolved";
+  return "Settled";
+}
+
+const ConvertToSharedRequest =
+  (chainId: ChainId, oracleAddress: Address, oracleType: OracleType) =>
+  (request: Request): SharedRequest => {
+    const {
+      requester,
+      identifier,
+      timestamp,
+      ancillaryData,
+      currency,
+      reward,
+      finalFee,
+      proposer,
+      proposedPrice,
+      expirationTime,
+      disputer,
+      price,
+      settleTx,
+      requestTx,
+      proposeTx,
+      disputeTx,
+      requestBlockNumber,
+      proposeBlockNumber,
+      disputeBlockNumber,
+      settleBlockNumber,
+      requestLogIndex,
+      proposeLogIndex,
+      disputeLogIndex,
+      settleLogIndex,
+      state,
+    } = request;
+    const id = requestId(request);
+
+    const result: SharedRequest = {
+      id,
+      chainId,
+      oracleAddress,
+      oracleType,
+      requester: assertAddress(requester),
+      identifier,
+      time: timestamp.toString(),
+      ancillaryData,
+    };
+    if (currency) result.currency = assertAddress(currency);
+    if (reward) result.reward = reward;
+    if (finalFee) result.finalFee = finalFee;
+    if (proposer) result.proposer = proposer;
+    if (proposedPrice) result.proposedPrice = proposedPrice;
+    if (expirationTime)
+      result.proposalExpirationTimestamp = expirationTime.toString();
+    if (disputer) result.disputer = disputer;
+    if (price) result.settlementPrice = price;
+    if (reward) result.settlementPayout = reward;
+    if (settleTx) result.settlementHash = settleTx;
+    if (requestBlockNumber)
+      result.requestBlockNumber = requestBlockNumber.toString();
+    if (requestTx) result.requestHash = requestTx;
+    if (price) result.settlementPrice = price;
+    if (reward) result.settlementPayout = reward;
+    if (settleTx) result.settlementHash = settleTx;
+    if (requestBlockNumber)
+      result.requestBlockNumber = requestBlockNumber.toString();
+    if (requestTx) result.requestHash = requestTx;
+    if (state) result.state = convertToSharedState(state);
+    if (proposeTx) result.proposalHash = proposeTx;
+    if (disputeTx) result.disputeHash = disputeTx;
+    if (proposeBlockNumber)
+      result.proposalBlockNumber = proposeBlockNumber.toString();
+    if (disputeBlockNumber)
+      result.disputeBlockNumber = disputeBlockNumber.toString();
+    if (requestLogIndex) result.requestLogIndex = requestLogIndex.toString();
+    if (proposeLogIndex) result.proposalLogIndex = proposeLogIndex.toString();
+    if (disputeLogIndex) result.disputeLogIndex = disputeLogIndex.toString();
+    if (settleBlockNumber)
+      result.settlementBlockNumber = settleBlockNumber.toString();
+    if (settleLogIndex) result.settlementLogIndex = settleLogIndex.toString();
+
+    // unable to get the following values, omit their keys to avoid
+    // overriding other sources when merged in final store
+    // dont know how this comes from events
+    // settlementRecipient: null
+    // settlementTimestamp: null,
+    // requestTimestamp: null,
+
+    return result;
+  };
+export type Api = {
+  updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
+};
+export const Factory = (config: Config): [ServiceFactory, Api] => {
+  const convertToSharedRequest = ConvertToSharedRequest(
+    config.chainId,
+    assertAddress(config.address),
+    "Optimistic Oracle V1"
+  );
+  const provider = new ethers.providers.JsonRpcProvider(config.url);
+  const oo = new OptimisticOracle(provider, config.address, config.chainId);
+  const events = new Events();
+  function updateFromTransactionReceipt(receipt: TransactionReceipt) {
+    oo.updateFromTransactionReceipt(receipt);
+    const requests: Request[] = oo.listRequests();
+    const sharedRequests = requests.map((request) =>
+      convertToSharedRequest(request)
+    );
+    events.emit("requests", sharedRequests);
+  }
+  const service = (handlers: Handlers): Service => {
+    if (handlers.requests) events.on("requests", handlers.requests);
+  };
+
+  return [
+    service,
+    {
+      updateFromTransactionReceipt,
+    },
+  ];
+};

--- a/libs/src/oracle-sdk-v2/services/oraclev1/ethers/index.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/ethers/index.ts
@@ -1,0 +1,1 @@
+export * from "./factory";

--- a/libs/src/oracle-sdk-v2/types.ts
+++ b/libs/src/oracle-sdk-v2/types.ts
@@ -20,7 +20,7 @@ export type Handlers = {
 
 export type Service = {
   tick: () => Promise<void>;
-};
+} | void;
 
 // this is the interface to implement a server, servers gather information about requests/assertions from any source
 export type ServiceFactory = (handlers: Handlers) => Service;

--- a/libs/src/types.ts
+++ b/libs/src/types.ts
@@ -1,12 +1,19 @@
-import type { Contract, ethers, providers, Event } from "ethers";
+import type { Contract, ethers, providers, Event, BigNumberish } from "ethers";
 import type {
   TypedEventFilterEthers as TypedEventFilter,
   TypedEventEthers as TypedEvent,
 } from "@uma/contracts-frontend";
 import type { Provider } from "@ethersproject/providers";
 import type { Signer } from "@ethersproject/abstract-signer";
+export type { Log } from "@ethersproject/abstract-provider";
+export type {
+  TransactionRequest,
+  TransactionReceipt,
+  TransactionResponse,
+} from "@ethersproject/abstract-provider";
 
 type Result = ethers.utils.Result;
+export type { Result, BigNumberish };
 
 export interface MakeId<I, D> {
   (d: D): I;

--- a/shared/utils/graphql.ts
+++ b/shared/utils/graphql.ts
@@ -1,3 +1,4 @@
+import assert from 'assert'
 import type {
   AssertionGraphEntity,
   ChainId,
@@ -12,6 +13,13 @@ import type {
 import { BigNumber } from "ethers";
 import type { Address } from "wagmi";
 
+export function isAddress(maybeAddress:string): maybeAddress is Address {
+  return '0x' == maybeAddress.slice(0,2)
+}
+export function assertAddress(maybeAddress:string): Address{
+  if(!isAddress(maybeAddress)) throw new Error(`${maybeAddress} is not a valid address.`)
+  return maybeAddress
+}
 export function handleGraphqlNullableStringOrBytes<
   EntityKey extends { [key: string]: string | null }
 >(entityKey: EntityKey | null) {

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import { getContractAddress } from "@libs/constants";
 import * as ss from "superstruct";
 
@@ -40,15 +39,16 @@ const Env = ss.object({
   NEXT_PUBLIC_SUBGRAPH_SKINNY_42161: ss.optional(ss.string()),
   NEXT_PUBLIC_SUBGRAPH_SKINNY_5: ss.optional(ss.string()),
 
-  NEXT_PUBLIC_PROVIDER_1: ss.optional(ss.string()),
-  NEXT_PUBLIC_PROVIDER_137: ss.optional(ss.string()),
-  NEXT_PUBLIC_PROVIDER_288: ss.optional(ss.string()),
-  NEXT_PUBLIC_PROVIDER_416: ss.optional(ss.string()),
-  NEXT_PUBLIC_PROVIDER_42161: ss.optional(ss.string()),
-  NEXT_PUBLIC_PROVIDER_43114: ss.optional(ss.string()),
-  NEXT_PUBLIC_PROVIDER_5: ss.optional(ss.string()),
-  NEXT_PUBLIC_PROVIDER_10: ss.optional(ss.string()),
-  NEXT_PUBLIC_PROVIDER_80001: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V1_1: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V1_137: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V1_288: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V1_42161: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V1_5: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V1_10: ss.optional(ss.string()),
+  // not supported yet
+  // NEXT_PUBLIC_PROVIDER_V1_416: ss.optional(ss.string()),
+  // NEXT_PUBLIC_PROVIDER_V1_43114: ss.optional(ss.string()),
+  // NEXT_PUBLIC_PROVIDER_V1_80001: ss.optional(ss.string()),
 });
 export type Env = ss.Infer<typeof Env>;
 
@@ -88,15 +88,18 @@ const env = ss.create(
       process.env.NEXT_PUBLIC_SUBGRAPH_SKINNY_42161,
     NEXT_PUBLIC_SUBGRAPH_SKINNY_5: process.env.NEXT_PUBLIC_SUBGRAPH_SKINNY_5,
 
-    NEXT_PUBLIC_PROVIDER_1: process.env.NEXT_PUBLIC_PROVIDER_1,
-    NEXT_PUBLIC_PROVIDER_137: process.env.NEXT_PUBLIC_PROVIDER_137,
-    NEXT_PUBLIC_PROVIDER_288: process.env.NEXT_PUBLIC_PROVIDER_288,
-    NEXT_PUBLIC_PROVIDER_416: process.env.NEXT_PUBLIC_PROVIDER_416,
-    NEXT_PUBLIC_PROVIDER_42161: process.env.NEXT_PUBLIC_PROVIDER_42161,
-    NEXT_PUBLIC_PROVIDER_43114: process.env.NEXT_PUBLIC_PROVIDER_43114,
-    NEXT_PUBLIC_PROVIDER_5: process.env.NEXT_PUBLIC_PROVIDER_5,
-    NEXT_PUBLIC_PROVIDER_10: process.env.NEXT_PUBLIC_PROVIDER_10,
-    NEXT_PUBLIC_PROVIDER_80001: process.env.NEXT_PUBLIC_PROVIDER_80001,
+    // enabling providers for each chain will enable web3 data services, which are needed for real time updates
+    NEXT_PUBLIC_PROVIDER_V1_1: process.env.NEXT_PUBLIC_PROVIDER_V1_1,
+    NEXT_PUBLIC_PROVIDER_V1_137: process.env.NEXT_PUBLIC_PROVIDER_V1_137,
+    NEXT_PUBLIC_PROVIDER_V1_288: process.env.NEXT_PUBLIC_PROVIDER_V1_288,
+    NEXT_PUBLIC_PROVIDER_V1_42161: process.env.NEXT_PUBLIC_PROVIDER_V1_42161,
+    NEXT_PUBLIC_PROVIDER_V1_5: process.env.NEXT_PUBLIC_PROVIDER_V1_5,
+    NEXT_PUBLIC_PROVIDER_V1_10: process.env.NEXT_PUBLIC_PROVIDER_V1_10,
+    // not supported yet
+    // NEXT_PUBLIC_PROVIDER_V1_416:   process.env.NEXT_PUBLIC_PROVIDER_V1_416,
+    // NEXT_PUBLIC_PROVIDER_V1_43114: process.env.NEXT_PUBLIC_PROVIDER_V1_43114,
+    // NEXT_PUBLIC_PROVIDER_V1_80001: process.env.NEXT_PUBLIC_PROVIDER_V1_80001,
+
     NEXT_PUBLIC_DEFAULT_LIVENESS: process.env.NEXT_PUBLIC_DEFAULT_LIVENESS,
   },
   Env
@@ -123,8 +126,16 @@ const SubgraphConfigs = ss.array(SubgraphConfig);
 export type SubgraphConfigs = ss.Infer<typeof SubgraphConfigs>;
 
 const ProviderConfig = ss.object({
+  source: ss.literal("provider"),
   chainId: ChainId,
+  type: ss.enums([
+    "Optimistic Oracle V1",
+    "Optimistic Oracle V2",
+    "Optimistic Oracle V3",
+    "Skinny Optimistic Oracle",
+  ]),
   url: ss.string(),
+  address: ss.string(),
 });
 export type ProviderConfig = ss.Infer<typeof ProviderConfig>;
 const ProviderConfigs = ss.array(ProviderConfig);
@@ -486,70 +497,72 @@ function parseEnv(env: Env): Config {
       }),
     });
   }
-  if (env.NEXT_PUBLIC_PROVIDER_1) {
+  if (env.NEXT_PUBLIC_PROVIDER_V1_1) {
     providers.push({
-      url: env.NEXT_PUBLIC_PROVIDER_1,
+      source: "provider",
+      type: "Optimistic Oracle V1",
+      url: env.NEXT_PUBLIC_PROVIDER_V1_1,
       chainId: 1,
+      address: getContractAddress({ chainId: 1, type: "Optimistic Oracle V1" }),
     });
   }
-  if (env.NEXT_PUBLIC_PROVIDER_137) {
+  if (env.NEXT_PUBLIC_PROVIDER_V1_137) {
     providers.push({
-      url: env.NEXT_PUBLIC_PROVIDER_137,
+      source: "provider",
+      type: "Optimistic Oracle V1",
+      url: env.NEXT_PUBLIC_PROVIDER_V1_137,
       chainId: 137,
+      address: getContractAddress({
+        chainId: 137,
+        type: "Optimistic Oracle V1",
+      }),
     });
   }
-  if (env.NEXT_PUBLIC_PROVIDER_288) {
+  if (env.NEXT_PUBLIC_PROVIDER_V1_288) {
     providers.push({
-      url: env.NEXT_PUBLIC_PROVIDER_288,
+      source: "provider",
+      type: "Optimistic Oracle V1",
+      url: env.NEXT_PUBLIC_PROVIDER_V1_288,
       chainId: 288,
+      address: getContractAddress({
+        chainId: 288,
+        type: "Optimistic Oracle V1",
+      }),
     });
   }
-  if (env.NEXT_PUBLIC_PROVIDER_416) {
+  if (env.NEXT_PUBLIC_PROVIDER_V1_42161) {
     providers.push({
-      url: env.NEXT_PUBLIC_PROVIDER_416,
-      chainId: 416,
-    });
-  }
-  if (env.NEXT_PUBLIC_PROVIDER_42161) {
-    providers.push({
-      url: env.NEXT_PUBLIC_PROVIDER_42161,
+      source: "provider",
+      type: "Optimistic Oracle V1",
+      url: env.NEXT_PUBLIC_PROVIDER_V1_42161,
       chainId: 42161,
+      address: getContractAddress({
+        chainId: 42161,
+        type: "Optimistic Oracle V1",
+      }),
     });
   }
-  if (env.NEXT_PUBLIC_PROVIDER_43114) {
+  if (env.NEXT_PUBLIC_PROVIDER_V1_5) {
     providers.push({
-      url: env.NEXT_PUBLIC_PROVIDER_43114,
-      chainId: 43114,
-    });
-  }
-  if (env.NEXT_PUBLIC_PROVIDER_5) {
-    providers.push({
-      url: env.NEXT_PUBLIC_PROVIDER_5,
+      source: "provider",
+      type: "Optimistic Oracle V1",
+      url: env.NEXT_PUBLIC_PROVIDER_V1_5,
       chainId: 5,
+      address: getContractAddress({ chainId: 5, type: "Optimistic Oracle V1" }),
     });
   }
-  if (env.NEXT_PUBLIC_PROVIDER_10) {
+  if (env.NEXT_PUBLIC_PROVIDER_V1_10) {
     providers.push({
-      url: env.NEXT_PUBLIC_PROVIDER_10,
+      source: "provider",
+      type: "Optimistic Oracle V1",
+      url: env.NEXT_PUBLIC_PROVIDER_V1_10,
       chainId: 10,
+      address: getContractAddress({
+        chainId: 10,
+        type: "Optimistic Oracle V1",
+      }),
     });
   }
-  if (env.NEXT_PUBLIC_PROVIDER_80001) {
-    providers.push({
-      url: env.NEXT_PUBLIC_PROVIDER_80001,
-      chainId: 80001,
-    });
-  }
-  // verify we have providers for all enable subgraph chains. If not checked we will have run time errors if providers are missing.
-  subgraphs.map((subgraph) => {
-    const found = providers.find(
-      (provider) => provider.chainId === subgraph.chainId
-    );
-    assert(
-      found,
-      `Subgraphs on chainId ${subgraph.chainId} requires a provider to be set for that chain as well: NEXT_PUBLIC_PROVIDER_${subgraph.chainId}`
-    );
-  });
   return {
     defaultApy: env.NEXT_PUBLIC_DEFAULT_APY ?? "30.1",
     infuraId: env.NEXT_PUBLIC_INFURA_ID,

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -12,6 +12,7 @@ import {
   useSwitchNetwork,
   useWaitForTransaction,
 } from "wagmi";
+import { oracleEthersApis } from "@/contexts";
 
 // This represents an action button, and the state we need to render it
 export type ActionState = Partial<{
@@ -209,8 +210,15 @@ export function useProposeAction({
       pending: <>Proposing price</>,
       success: <>Proposed price</>,
       error: <>Failed to propose price</>,
-    }).catch(console.error);
-  }, [proposePriceTransaction, chainId]);
+    })
+      .then((receipt) => {
+        if (receipt && query)
+          oracleEthersApis?.[query.oracleType]?.[
+            chainId
+          ]?.updateFromTransactionReceipt(receipt);
+      })
+      .catch(console.error);
+  }, [proposePriceTransaction, chainId, query]);
 
   if (proposePriceParams === undefined) return undefined;
 
@@ -269,8 +277,15 @@ export function useDisputeAction({
       pending: <>Disputing price</>,
       success: <>Disputed price</>,
       error: <>Failed to dispute price</>,
-    }).catch(console.error);
-  }, [disputePriceTransaction, chainId]);
+    })
+      .then((receipt) => {
+        if (receipt && query)
+          oracleEthersApis?.[query.oracleType]?.[
+            chainId
+          ]?.updateFromTransactionReceipt(receipt);
+      })
+      .catch(console.error);
+  }, [disputePriceTransaction, chainId, query]);
 
   if (disputePriceParams === undefined) return undefined;
 


### PR DESCRIPTION
## motivation
we want to be able to update our oo query data when users change the state through transactions

## changes
This only adds oo v1 realtime updates based on transaction reciepts. It builds this into the service architecture so that updates are issued through the same logic defined in the oracle data context.  it hooks into the actions hook, and waits for txs to complete before passing these receipts into the service. 

## testing
this is difficult to test currently, and probably is not working correctly just yet. this will be followed up with prs to help refactor and add the rest of the oracles.