### PR TITLE
fix: set all counts for existing filters to zero on change

### DIFF
--- a/src/hooks/filters.ts
+++ b/src/hooks/filters.ts
@@ -133,11 +133,19 @@ function filtersReducer(queries: OracleQueryUI[]) {
   return function reducer(oldState: State, action: Action) {
     switch (action.type) {
       case "make-entries": {
-        const newState = cloneDeep(initialState);
+        const newState = cloneDeep(oldState);
 
         newState.filters.project.All.count = queries.length;
         newState.filters.chainName.All.count = queries.length;
         newState.filters.oracleType.All.count = queries.length;
+
+        Object.values(newState.filters).forEach((filter) => {
+          Object.entries(filter).forEach(([itemName, item]) => {
+            if (itemName !== "All") {
+              item.count = 0;
+            }
+          });
+        });
 
         queries.forEach((query) => {
           const { project, chainName, oracleType } = query;


### PR DESCRIPTION
### Motivation

When we change pages, its possible that there are items from previous filter selections that have no entries on the new page. Previously I was simply clearing those away and removing those filter options. This caused a problem where the filter selection state is lost when navigating to a page that does actually have queries for that option.

### Changes

* When we make our filter entries, we use the old state as the basis and set all the existing counts to zero.