### PR TITLE
feat: add v3 receipt parsing

### DIFF
--- a/libs/src/clients/index.ts
+++ b/libs/src/clients/index.ts
@@ -4,3 +4,4 @@ export * as multicall2 from "./multicall2";
 export * as optimisticOracle from "./optimisticOracle";
 export * as skinnyOptimisticOracle from "./skinnyOptimisticOracle";
 export * as optimisticOracleV2 from "./optimisticOracleV2";
+export * as optimisticOracleV3 from "./optimisticOracleV3";

--- a/libs/src/clients/optimisticOracleV3/client.ts
+++ b/libs/src/clients/optimisticOracleV3/client.ts
@@ -1,0 +1,170 @@
+import type { OptimisticOracleV3InterfaceEthers } from "@uma/contracts-frontend";
+import {
+  OptimisticOracleV3InterfaceEthers__factory,
+  getOptimisticOracleV3InterfaceAbi,
+} from "@uma/contracts-frontend";
+import type {
+  SerializableEvent,
+  SignerOrProvider,
+  GetEventType,
+} from "@libs/types";
+import type { BigNumber } from "ethers";
+import { utils } from "ethers";
+
+export type Instance = OptimisticOracleV3InterfaceEthers;
+const Factory = OptimisticOracleV3InterfaceEthers__factory;
+
+export function connect(address: string, provider: SignerOrProvider): Instance {
+  return Factory.connect(address, provider);
+}
+
+export const contractInterface = new utils.Interface(
+  getOptimisticOracleV3InterfaceAbi()
+);
+
+export type AssertionMade = GetEventType<Instance, "AssertionMade">;
+export type AssertionDisputed = GetEventType<Instance, "AssertionDisputed">;
+export type AssertionSettled = GetEventType<Instance, "AssertionSettled">;
+export type AdminPropertiesSet = GetEventType<Instance, "AdminPropertiesSet">;
+
+export type EscalationManagerSettings = {
+  arbitrateViaEscalationManager: boolean; // False if the DVM is used as an oracle (EscalationManager on True).
+  discardOracle: boolean; // False if Oracle result is used for resolving assertion after dispute.
+  validateDisputers: boolean; // True if the EM isDisputeAllowed should be checked on disputes.
+  assertingCaller: string; // Stores msg.sender when assertion was made.
+  escalationManager: string; // Address of the escalation manager (zero address if not configured).
+};
+export type Assertion = {
+  assertionId: string;
+} & Partial<{
+  // data exclusively emitted by events
+  claim: string;
+  disputed: boolean;
+  bondRecipient: string;
+  assertionCaller: string;
+  disputeCaller: string;
+  settleCaller: string;
+  // defined in assertion state in contract
+  escalationManagerSettings: Partial<EscalationManagerSettings>; // Settings related to the escalation manager.
+  asserter: string; // Address of the asserter.
+  assertionTime: BigNumber; // Time of the assertion.
+  settled: boolean; // True if the request is settled.
+  currency: string; // ERC20 token used to pay rewards and fees.
+  expirationTime: BigNumber; // Unix timestamp marking threshold when the assertion can no longer be disputed.
+  settlementResolution: boolean; // Resolution of the assertion (false till resolved).
+  domainId: string; // Optional domain that can be used to relate the assertion to others in the escalationManager.
+  identifier: string; // UMA DVM identifier to use for price requests in the event of a dispute.
+  bond: BigNumber; // Amount of currency that the asserter has bonded.
+  callbackRecipient: string; // Address that receives the callback.
+  disputer: string; // Address of the disputer.
+  // meta data from event block
+  assertionTx: string;
+  assertionBlockNumber: number;
+  assertionLogIndex: number;
+  disputeTx: string;
+  disputeBlockNumber: number;
+  disputeLogIndex: number;
+  settleTx: string;
+  settleBlockNumber: number;
+  settleLogIndex: number;
+}>;
+
+export interface EventState {
+  assertions?: Record<string, Assertion>;
+}
+
+export function reduceEvents(
+  state: EventState,
+  event: SerializableEvent
+): EventState {
+  switch (event.event) {
+    case "AssertionMade": {
+      const typedEvent = event as AssertionMade;
+      const {
+        assertionId,
+        domainId,
+        claim,
+        asserter,
+        callbackRecipient,
+        escalationManager,
+        caller,
+        expirationTime,
+        currency,
+        bond,
+        identifier,
+      } = typedEvent.args;
+      if (!state.assertions) state.assertions = {};
+      const assertion: Assertion = state.assertions[assertionId];
+      const escalationManagerSettings: Partial<EscalationManagerSettings> =
+        assertion.escalationManagerSettings || {};
+      state.assertions[assertionId] = {
+        ...assertion,
+        assertionId,
+        domainId,
+        claim,
+        asserter,
+        callbackRecipient,
+        escalationManagerSettings: {
+          ...escalationManagerSettings,
+          escalationManager,
+        },
+        assertionCaller: caller,
+        expirationTime,
+        currency,
+        bond,
+        identifier,
+        assertionTx: event.transactionHash,
+        assertionBlockNumber: event.blockNumber,
+        assertionLogIndex: event.logIndex,
+      };
+      break;
+    }
+    case "AssertionDisputed": {
+      const typedEvent = event as AssertionDisputed;
+      const { assertionId, caller, disputer } = typedEvent.args;
+      if (!state.assertions) state.assertions = {};
+      const assertion: Assertion = state.assertions[assertionId];
+      state.assertions[assertionId] = {
+        ...assertion,
+        assertionId,
+        disputeCaller: caller,
+        disputer,
+        disputeTx: event.transactionHash,
+        disputeBlockNumber: event.blockNumber,
+        disputeLogIndex: event.logIndex,
+      };
+      break;
+    }
+    case "AssertionSettled": {
+      const typedEvent = event as AssertionSettled;
+      const {
+        assertionId,
+        bondRecipient,
+        disputed,
+        settlementResolution,
+        settleCaller,
+      } = typedEvent.args;
+      if (!state.assertions) state.assertions = {};
+      const assertion: Assertion = state.assertions[assertionId];
+      state.assertions[assertionId] = {
+        ...assertion,
+        assertionId,
+        bondRecipient,
+        disputed,
+        settlementResolution,
+        settleCaller,
+        settleTx: event.transactionHash,
+        settleBlockNumber: event.blockNumber,
+        settleLogIndex: event.logIndex,
+      };
+      break;
+    }
+  }
+  return state;
+}
+export function getEventState(
+  events: SerializableEvent[],
+  eventState: EventState = {}
+): EventState {
+  return events.reduce(reduceEvents, eventState);
+}

--- a/libs/src/clients/optimisticOracleV3/index.ts
+++ b/libs/src/clients/optimisticOracleV3/index.ts
@@ -1,0 +1,1 @@
+export * from "./client";

--- a/libs/src/oracle-sdk-v2/services/index.ts
+++ b/libs/src/oracle-sdk-v2/services/index.ts
@@ -5,4 +5,5 @@ export * as oracle2Gql from "./oraclev1/gql";
 // oracle skinny is same as oracle 1
 export * as oracle2SkinnyGql from "./oraclev1/gql";
 export * as oracle3Gql from "./oraclev3/gql";
+export * as oracle3Ethers from "./oraclev3/ethers";
 export * as oracles from "./oracles";

--- a/libs/src/oracle-sdk-v2/services/oraclev3/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/ethers/factory.ts
@@ -1,0 +1,159 @@
+import Events from "events";
+import { ethers } from "ethers";
+import type { Interface } from "@ethersproject/abi";
+import { assertAddress } from "@shared/utils";
+import type { Assertion as SharedAssertion, ChainId } from "@shared/types";
+import type { Address } from "wagmi";
+import type {
+  Handlers,
+  Service,
+  ServiceFactory,
+} from "@libs/oracle-sdk-v2/types";
+import type { TransactionReceipt, SerializableEvent } from "@libs/types";
+import type { Assertion } from "@libs/clients/optimisticOracleV3";
+import { connect, getEventState } from "@libs/clients/optimisticOracleV3";
+
+type Log = Parameters<Interface["parseLog"]>[0];
+export type Config = {
+  chainId: ChainId;
+  url: string;
+  address: string;
+};
+
+const ConvertToSharedAssertion =
+  (chainId: ChainId, oracleAddress: Address) =>
+  (assertion: Assertion): SharedAssertion => {
+    const {
+      assertionId,
+      claim,
+      assertionCaller,
+
+      // unused?
+      // disputed,
+      // bondRecipient,
+      // disputeCaller,
+      // settleCaller,
+      // settled,
+      // domainId,
+
+      escalationManagerSettings,
+      asserter,
+      assertionTime,
+      currency,
+      expirationTime,
+      settlementResolution,
+      identifier,
+      bond,
+      callbackRecipient,
+      disputer,
+
+      assertionTx,
+      assertionBlockNumber,
+      assertionLogIndex,
+      disputeTx,
+      disputeBlockNumber,
+      disputeLogIndex,
+      settleTx,
+      settleBlockNumber,
+      settleLogIndex,
+    } = assertion;
+
+    const result: SharedAssertion = {
+      id: assertionId,
+      assertionId,
+      chainId,
+      oracleAddress,
+      oracleType: "Optimistic Oracle V3",
+    };
+    if (claim) result.claim = claim;
+    if (asserter) result.asserter = asserter;
+    if (identifier) result.identifier = identifier;
+    if (callbackRecipient) result.callbackRecipient = callbackRecipient;
+    if (escalationManagerSettings?.escalationManager)
+      result.escalationManager = escalationManagerSettings.escalationManager;
+    if (assertionCaller) result.caller = assertionCaller;
+    if (expirationTime) result.expirationTime = expirationTime.toString();
+    if (currency) result.currency = assertAddress(currency);
+    if (settlementResolution)
+      result.settlementResolution = settlementResolution;
+    if (bond) result.bond = bond;
+    if (assertionTime) result.assertionTimestamp = assertionTime.toString();
+    if (assertionBlockNumber)
+      result.assertionBlockNumber = assertionBlockNumber.toString();
+    if (assertionTx) result.assertionHash = assertionTx;
+    if (assertionLogIndex)
+      result.assertionLogIndex = assertionLogIndex.toString();
+    if (disputer) result.disputer = disputer;
+    // unknown how to get this from events
+    // if (settlementPayout) result.settlementPayout = settlementPayout;
+    // if (settlementRecipient) result.settlementRecipient = settlementRecipient;
+    // if (disputeTimestamp) result.disputeTimestamp = disputeTimestamp;
+    if (disputeBlockNumber)
+      result.disputeBlockNumber = disputeBlockNumber.toString();
+    if (disputeTx) result.disputeHash = disputeTx;
+    if (disputeLogIndex) result.disputeLogIndex = disputeLogIndex.toString();
+    if (settleTx) result.settlementHash = settleTx;
+    if (settleBlockNumber)
+      result.settlementBlockNumber = settleBlockNumber.toString();
+    if (settleLogIndex) result.settlementLogIndex = settleLogIndex.toString();
+
+    return result;
+  };
+export type Api = {
+  updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
+};
+export const Factory = (config: Config): [ServiceFactory, Api] => {
+  const convertToSharedAssertion = ConvertToSharedAssertion(
+    config.chainId,
+    assertAddress(config.address)
+  );
+  const provider = new ethers.providers.JsonRpcProvider(config.url);
+  const contract = connect(config.address, provider);
+  // const oo = new OptimisticOracle(provider, config.address, config.chainId);
+  const events = new Events();
+
+  function parseLog(log: Log) {
+    const description = contract.interface.parseLog(log);
+    return {
+      ...log,
+      ...description,
+      event: description.name,
+      eventSignature: description.signature,
+    };
+  }
+
+  function updateFromTransactionReceipt(receipt: TransactionReceipt) {
+    try {
+      const parsedLogs = receipt.logs
+        .map((log) => {
+          // ignore errors, its possible to have logs from other contracts in receipt
+          try {
+            return parseLog(log);
+          } catch (err) {
+            return false;
+          }
+        })
+        .filter((x) => x);
+
+      const { assertions = {} } = getEventState(
+        parsedLogs as unknown as SerializableEvent[]
+      );
+      const sharedAssertions = Object.values(assertions).map((assertion) =>
+        convertToSharedAssertion(assertion)
+      );
+      events.emit("assertions", sharedAssertions);
+    } catch (err) {
+      console.warn("Error updating v3 from tx receipt:", err);
+    }
+  }
+  const service = (handlers: Handlers): Service => {
+    if (handlers.assertions) events.on("assertions", handlers.assertions);
+  };
+
+  return [
+    service,
+    {
+      updateFromTransactionReceipt,
+    },
+  ];
+};

--- a/libs/src/oracle-sdk-v2/services/oraclev3/ethers/index.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/ethers/index.ts
@@ -1,0 +1,1 @@
+export * from "./factory";

--- a/shared/types/oracle.ts
+++ b/shared/types/oracle.ts
@@ -25,12 +25,13 @@ export type Assertion = {
   oracleAddress: Address;
   oracleType: OracleType;
   id:string,
+  assertionId: string;
+} & Partial<{
   identifier: string;
   asserter: string;
   claim: string;
   assertionTimestamp: string;
-  assertionId: string;
-} & Partial<ParsedOOV3GraphEntity>;
+}> & Partial<ParsedOOV3GraphEntity>;
 
 export type Requests = Request[];
 

--- a/src/components/OracleQueryList/ItemDetails.tsx
+++ b/src/components/OracleQueryList/ItemDetails.tsx
@@ -34,7 +34,8 @@ export function ItemDetails({
         <ItemDetailsText>Proposal/Assertion</ItemDetailsText>
         <ItemDetailsText>{valueText}</ItemDetailsText>
       </ItemDetailsInnerWrapper>
-      {livenessEndsMilliseconds !== null && (
+      {livenessEndsMilliseconds !== undefined &&
+      timeMilliseconds !== undefined ? (
         <ItemDetailsInnerWrapper>
           <ItemDetailsText>Challenge Period Left</ItemDetailsText>
           <LivenessProgressBar
@@ -44,7 +45,7 @@ export function ItemDetails({
             marginBottom={0}
           />
         </ItemDetailsInnerWrapper>
-      )}
+      ) : undefined}
     </ItemDetailsWrapper>
   );
 

--- a/src/components/OracleQueryTable/VerifyCells.tsx
+++ b/src/components/OracleQueryTable/VerifyCells.tsx
@@ -12,7 +12,8 @@ export function VerifyCells({
       <TD>
         <Text>{valueText}</Text>
       </TD>
-      {livenessEndsMilliseconds !== undefined ? (
+      {livenessEndsMilliseconds !== undefined &&
+      timeMilliseconds !== undefined ? (
         <TD>
           <LivenessProgressBar
             startTime={timeMilliseconds}

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -39,12 +39,21 @@ const Env = ss.object({
   NEXT_PUBLIC_SUBGRAPH_SKINNY_42161: ss.optional(ss.string()),
   NEXT_PUBLIC_SUBGRAPH_SKINNY_5: ss.optional(ss.string()),
 
+  // enabling services for realtime updates oo v1
   NEXT_PUBLIC_PROVIDER_V1_1: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_V1_137: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_V1_288: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_V1_42161: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_V1_5: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_V1_10: ss.optional(ss.string()),
+
+  // enabling services for realtime updates oo v3
+  NEXT_PUBLIC_PROVIDER_V3_1: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V3_137: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V3_288: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V3_42161: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V3_5: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V3_10: ss.optional(ss.string()),
   // not supported yet
   // NEXT_PUBLIC_PROVIDER_V1_416: ss.optional(ss.string()),
   // NEXT_PUBLIC_PROVIDER_V1_43114: ss.optional(ss.string()),
@@ -95,6 +104,12 @@ const env = ss.create(
     NEXT_PUBLIC_PROVIDER_V1_42161: process.env.NEXT_PUBLIC_PROVIDER_V1_42161,
     NEXT_PUBLIC_PROVIDER_V1_5: process.env.NEXT_PUBLIC_PROVIDER_V1_5,
     NEXT_PUBLIC_PROVIDER_V1_10: process.env.NEXT_PUBLIC_PROVIDER_V1_10,
+    NEXT_PUBLIC_PROVIDER_V3_1: process.env.NEXT_PUBLIC_PROVIDER_V3_1,
+    NEXT_PUBLIC_PROVIDER_V3_137: process.env.NEXT_PUBLIC_PROVIDER_V3_137,
+    NEXT_PUBLIC_PROVIDER_V3_288: process.env.NEXT_PUBLIC_PROVIDER_V3_288,
+    NEXT_PUBLIC_PROVIDER_V3_42161: process.env.NEXT_PUBLIC_PROVIDER_V3_42161,
+    NEXT_PUBLIC_PROVIDER_V3_5: process.env.NEXT_PUBLIC_PROVIDER_V3_5,
+    NEXT_PUBLIC_PROVIDER_V3_10: process.env.NEXT_PUBLIC_PROVIDER_V3_10,
     // not supported yet
     // NEXT_PUBLIC_PROVIDER_V1_416:   process.env.NEXT_PUBLIC_PROVIDER_V1_416,
     // NEXT_PUBLIC_PROVIDER_V1_43114: process.env.NEXT_PUBLIC_PROVIDER_V1_43114,
@@ -560,6 +575,72 @@ function parseEnv(env: Env): Config {
       address: getContractAddress({
         chainId: 10,
         type: "Optimistic Oracle V1",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V3_1) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V3",
+      url: env.NEXT_PUBLIC_PROVIDER_V3_1,
+      chainId: 1,
+      address: getContractAddress({ chainId: 1, type: "Optimistic Oracle V3" }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V3_137) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V3",
+      url: env.NEXT_PUBLIC_PROVIDER_V3_137,
+      chainId: 137,
+      address: getContractAddress({
+        chainId: 137,
+        type: "Optimistic Oracle V3",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V3_288) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V3",
+      url: env.NEXT_PUBLIC_PROVIDER_V3_288,
+      chainId: 288,
+      address: getContractAddress({
+        chainId: 288,
+        type: "Optimistic Oracle V3",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V3_42161) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V3",
+      url: env.NEXT_PUBLIC_PROVIDER_V3_42161,
+      chainId: 42161,
+      address: getContractAddress({
+        chainId: 42161,
+        type: "Optimistic Oracle V3",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V3_5) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V3",
+      url: env.NEXT_PUBLIC_PROVIDER_V3_5,
+      chainId: 5,
+      address: getContractAddress({ chainId: 5, type: "Optimistic Oracle V3" }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V3_10) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V3",
+      url: env.NEXT_PUBLIC_PROVIDER_V3_10,
+      chainId: 10,
+      address: getContractAddress({
+        chainId: 10,
+        type: "Optimistic Oracle V3",
       }),
     });
   }

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -6,7 +6,11 @@ import {
 } from "@/helpers";
 import type { OracleQueryUI } from "@/types";
 import { Client } from "@libs/oracle-sdk-v2";
-import { oracles, oracle1Ethers } from "@libs/oracle-sdk-v2/services";
+import {
+  oracles,
+  oracle1Ethers,
+  oracle3Ethers,
+} from "@libs/oracle-sdk-v2/services";
 import type { Api } from "@libs/oracle-sdk-v2/services/oraclev1/ethers";
 import type { ServiceFactories, ServiceFactory } from "@libs/oracle-sdk-v2";
 import type { ProviderConfig } from "@/constants";
@@ -32,10 +36,15 @@ type EthersServicesList = [
 const ethersServicesListInit: EthersServicesList = [[], {}];
 const [oracleEthersServices, oracleEthersApis] = config.providers
   // TODO: this needs to be updated with oracle v2, v3, skinny based on config
-  .map((config): [ProviderConfig, ServiceFactory, Api] => [
-    config,
-    ...oracle1Ethers.Factory(config),
-  ])
+  .map((config): [ProviderConfig, ServiceFactory, Api] => {
+    if (config.type === "Optimistic Oracle V1")
+      return [config, ...oracle1Ethers.Factory(config)];
+    if (config.type === "Optimistic Oracle V3")
+      return [config, ...oracle3Ethers.Factory(config)];
+    throw new Error(
+      `App configured with unsupported oracle type: ${config.type}`
+    );
+  })
   .reduce(
     (
       result: EthersServicesList,

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -526,11 +526,13 @@ function makeMoreInformationList(
   }
 
   if (isAssertion(query)) {
-    moreInformation.push({
-      title: "Asserter",
-      text: query.asserter,
-      href: makeBlockExplorerLink(query.asserter, query.chainId, "address"),
-    });
+    if (query.asserter) {
+      moreInformation.push({
+        title: "Asserter",
+        text: query.asserter,
+        href: makeBlockExplorerLink(query.asserter, query.chainId, "address"),
+      });
+    }
     if (query.escalationManager) {
       moreInformation.push({
         title: "Escalation Manager",
@@ -813,18 +815,23 @@ export function assertionToOracleQuery(assertion: Assertion): OracleQueryUI {
   } = assertion;
   const oracleType = "Optimistic Oracle V3";
   const id = assertionId;
-  const livenessEndsMilliseconds = getLivenessEnds(expirationTime);
-  const formattedLivenessEndsIn = toTimeFormatted(livenessEndsMilliseconds);
+  let livenessEndsMilliseconds = undefined;
+  let formattedLivenessEndsIn = undefined;
+  if (expirationTime) {
+    livenessEndsMilliseconds = getLivenessEnds(expirationTime);
+    formattedLivenessEndsIn = toTimeFormatted(livenessEndsMilliseconds);
+  }
   const chainName = getChainName(chainId);
-  const timeUTC = toTimeUTC(assertionTimestamp);
-  const timeUNIX = toTimeUnix(assertionTimestamp);
-  const timeMilliseconds = toTimeMilliseconds(assertionTimestamp);
-  const timeFormatted = toTimeFormatted(assertionTimestamp);
   const valueText = settlementResolution
     ? settlementResolution.toString()
     : null;
-  const queryTextHex = claim;
-  const queryText = safeDecodeHexString(claim);
+  let queryTextHex = undefined;
+  let queryText = undefined;
+  if (claim) {
+    queryTextHex = claim;
+    queryText = safeDecodeHexString(claim);
+  }
+
   const title = queryText;
   const description = queryText;
   const project = "UMA";
@@ -861,6 +868,14 @@ export function assertionToOracleQuery(assertion: Assertion): OracleQueryUI {
   const proposePriceParams = undefined;
   const disputePriceParams = undefined;
   const settlePriceParams = undefined;
+
+  let timeUTC, timeUNIX, timeMilliseconds, timeFormatted;
+  if (assertionTimestamp) {
+    timeUTC = toTimeUTC(assertionTimestamp);
+    timeUNIX = toTimeUnix(assertionTimestamp);
+    timeMilliseconds = toTimeMilliseconds(assertionTimestamp);
+    timeFormatted = toTimeFormatted(assertionTimestamp);
+  }
 
   return {
     id,

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -106,8 +106,14 @@ export function sortQueriesByDate({
   settled: OracleQueryList;
 }) {
   return {
-    verify: verify.sort((a, b) => b.timeMilliseconds - a.timeMilliseconds),
-    propose: propose.sort((a, b) => b.timeMilliseconds - a.timeMilliseconds),
-    settled: settled.sort((a, b) => b.timeMilliseconds - a.timeMilliseconds),
+    verify: verify.sort(
+      (a, b) => (b.timeMilliseconds || 0) - (a.timeMilliseconds || 0)
+    ),
+    propose: propose.sort(
+      (a, b) => (b.timeMilliseconds || 0) - (a.timeMilliseconds || 0)
+    ),
+    settled: settled.sort(
+      (a, b) => (b.timeMilliseconds || 0) - (a.timeMilliseconds || 0)
+    ),
   };
 }

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -336,8 +336,15 @@ export function useDisputeAssertionAction({
       pending: <>Disputing assertion</>,
       success: <>Disputed assertion</>,
       error: <>Failed to dispute assertion</>,
-    }).catch(console.error);
-  }, [disputeAssertionTransaction, chainId]);
+    })
+      .then((receipt) => {
+        if (receipt && query)
+          oracleEthersApis?.[query.oracleType]?.[
+            chainId
+          ]?.updateFromTransactionReceipt(receipt);
+      })
+      .catch(console.error);
+  }, [disputeAssertionTransaction, chainId, query]);
 
   if (disputeAssertionParams === undefined) return undefined;
 
@@ -389,8 +396,15 @@ export function useSettlePriceAction({
       pending: <>Settling price</>,
       success: <>Settled price</>,
       error: <>Failed to settle price</>,
-    }).catch(console.error);
-  }, [settlePriceTransaction, chainId]);
+    })
+      .then((receipt) => {
+        if (receipt && query)
+          oracleEthersApis?.[query.oracleType]?.[
+            chainId
+          ]?.updateFromTransactionReceipt(receipt);
+      })
+      .catch(console.error);
+  }, [settlePriceTransaction, chainId, query]);
 
   if (settlePriceParams === undefined) return undefined;
 
@@ -445,8 +459,15 @@ export function useSettleAssertionAction({
       pending: <>Settling assertion</>,
       success: <>Settled assertion</>,
       error: <>Failed to settle assertion</>,
-    }).catch(console.error);
-  }, [settleAssertionTransaction, chainId]);
+    })
+      .then((receipt) => {
+        if (receipt && query)
+          oracleEthersApis?.[query.oracleType]?.[
+            chainId
+          ]?.updateFromTransactionReceipt(receipt);
+      })
+      .catch(console.error);
+  }, [settleAssertionTransaction, chainId, query]);
 
   if (settleAssertionParams === undefined) return undefined;
 

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -60,22 +60,23 @@ export type OracleQueryUI = {
   project: Project;
   title: ReactNode;
   description: ReactNode;
-  identifier: string;
   expiryType: ExpiryType | null;
   oracleAddress: Address;
+  // not always available with assertions
+  identifier?: string;
   // price requests query text is the ancillary data
   // for assertions it is the `claim` field
-  queryTextHex: string;
-  queryText: string;
+  queryTextHex?: string;
+  queryText?: string;
   // for price requests the value text is null until a price is proposed. Then it is the proposed price. After a price is settled it is the settled price.
   // for assertions the value text is null until settlement, after which it is the `settlementResolution` field
   valueText: string | null;
-  timeUTC: string;
-  timeUNIX: number;
-  timeMilliseconds: number;
-  timeFormatted: string;
-  livenessEndsMilliseconds: number;
-  formattedLivenessEndsIn: string;
+  timeUTC?: string;
+  timeUNIX?: number;
+  timeMilliseconds?: number;
+  timeFormatted?: string;
+  livenessEndsMilliseconds?: number;
+  formattedLivenessEndsIn?: string;
   actionType: ActionType | null;
   moreInformation: MoreInformationItem[];
   // for oo-v1 bond is the final fee


### PR DESCRIPTION
## motivation
we want to have state updates when user submits txs that change oracle v3 queries

## changes
this does a lot of similar things to the v1 receipt update logic, but we needed to specifically add v3 event to state parsers since we didnt have those from the original sdk. we also have to loosen the UI types because there is some data that is not gauranteed when parsing from events.