### PR TITLE
fix: fix settle and other issues

### DIFF
--- a/libs/src/oracle-sdk-v2/services/oraclev3/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/ethers/factory.ts
@@ -2,6 +2,7 @@ import Events from "events";
 import { ethers } from "ethers";
 import type { Interface } from "@ethersproject/abi";
 import { assertAddress } from "@shared/utils";
+import { parseIdentifier } from "@libs/utils";
 import type { Assertion as SharedAssertion, ChainId } from "@shared/types";
 import type { Address } from "wagmi";
 import type {
@@ -67,7 +68,7 @@ const ConvertToSharedAssertion =
     };
     if (claim) result.claim = claim;
     if (asserter) result.asserter = asserter;
-    if (identifier) result.identifier = identifier;
+    if (identifier) result.identifier = parseIdentifier(identifier);
     if (callbackRecipient) result.callbackRecipient = callbackRecipient;
     if (escalationManagerSettings?.escalationManager)
       result.escalationManager = escalationManagerSettings.escalationManager;

--- a/libs/src/utils.ts
+++ b/libs/src/utils.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import type { Contract } from "ethers";
-import { BigNumber } from "ethers";
+import { BigNumber, ethers } from "ethers";
 import type Multicall2 from "./multicall2";
 import zip from "lodash/zip";
 import sortedLastIndexBy from "lodash/sortedLastIndexBy";
@@ -190,4 +190,11 @@ export function isUnique<T>(
     return id(next) === elementId;
   });
   return found === undefined;
+}
+
+export function parseIdentifier(identifier: string | null | undefined): string {
+  // replace non ascii chars
+  return ethers.utils
+    .toUtf8String(identifier || [])
+    .replace(/[^\x20-\x7E]+/g, "");
 }

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -3,6 +3,7 @@ import type { OracleQueryUI } from "@/types";
 import { useRouter } from "next/router";
 import type { ReactNode } from "react";
 import { createContext, useEffect, useState } from "react";
+import { useOracleDataContext } from "@/hooks";
 
 export interface PanelContextState {
   panelOpen: boolean;
@@ -26,7 +27,8 @@ export const PanelContext = createContext<PanelContextState>(
 );
 
 export function PanelProvider({ children }: { children: ReactNode }) {
-  const [content, setContent] = useState<OracleQueryUI | undefined>();
+  const { all } = useOracleDataContext();
+  const [id, setId] = useState<string | undefined>();
   const [panelOpen, setPanelOpen] = useState(false);
   const router = useRouter();
 
@@ -55,9 +57,11 @@ export function PanelProvider({ children }: { children: ReactNode }) {
       await router.push({ query });
     }
 
-    setContent(content);
+    setId(content.id);
     setPanelOpen(true);
   }
+  const content: OracleQueryUI | undefined =
+    all !== undefined && id !== undefined ? all[id] : undefined;
 
   async function closePanel() {
     await router.push({ query: {} });

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -8,10 +8,10 @@ import {
   connectingWallet,
   dispute,
   disputing,
+  disputed,
   insufficientBalance,
   propose,
   settle,
-  settled,
   settling,
 } from "@/constants";
 import { handleNotifications } from "@/helpers";
@@ -50,17 +50,17 @@ export function usePrimaryPanelAction({
   const proposeAction = useProposeAction({ query, proposePriceInput });
   const disputeAction = useDisputeAction({ query });
   const disputeAssertionAction = useDisputeAssertionAction({ query });
-  // TODO: work out settle logic. need to clarify how we can detect when to show settle, and interactions
-  // between change chain action, settle action and showing settled when on wrong chain
-  // const settlePriceAction = useSettlePriceAction({ query });
-  // const settleAssertionAction = useSettleAssertionAction({ query });
+  const settlePriceAction = useSettlePriceAction({ query });
+  const settleAssertionAction = useSettleAssertionAction({ query });
 
   return (
     accountAction ||
     approveBondAction ||
     proposeAction ||
     disputeAction ||
-    disputeAssertionAction
+    disputeAssertionAction ||
+    settlePriceAction ||
+    settleAssertionAction
   );
 }
 
@@ -238,7 +238,8 @@ export function useProposeAction({
           ]?.updateFromTransactionReceipt(receipt);
       })
       .catch(console.error);
-  }, [proposePriceTransaction, chainId, query]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [proposePriceTransaction]);
 
   if (proposePriceParams === undefined) return undefined;
 
@@ -305,7 +306,8 @@ export function useDisputeAction({
           ]?.updateFromTransactionReceipt(receipt);
       })
       .catch(console.error);
-  }, [disputePriceTransaction, chainId, query]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disputePriceTransaction]);
 
   if (disputePriceParams === undefined) return undefined;
 
@@ -364,7 +366,8 @@ export function useDisputeAssertionAction({
           ]?.updateFromTransactionReceipt(receipt);
       })
       .catch(console.error);
-  }, [disputeAssertionTransaction, chainId, query]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disputeAssertionTransaction]);
 
   if (disputeAssertionParams === undefined) return undefined;
 
@@ -424,7 +427,8 @@ export function useSettlePriceAction({
           ]?.updateFromTransactionReceipt(receipt);
       })
       .catch(console.error);
-  }, [settlePriceTransaction, chainId, query]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settlePriceTransaction]);
 
   if (settlePriceParams === undefined) return undefined;
 
@@ -440,10 +444,11 @@ export function useSettlePriceAction({
       disabled: true,
     };
   }
-  // unique to settle, if we have an error preparing the transaction, this usually means the request has been settled
+  // unique to settle, if we have an error preparing the transaction,
+  // this means this is probably disputed, but no answer available from dvm yet
   if (prepareSettlePriceError) {
     return {
-      title: settled,
+      title: disputed,
       disabled: true,
     };
   }
@@ -487,7 +492,8 @@ export function useSettleAssertionAction({
           ]?.updateFromTransactionReceipt(receipt);
       })
       .catch(console.error);
-  }, [settleAssertionTransaction, chainId, query]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settleAssertionTransaction]);
 
   if (settleAssertionParams === undefined) return undefined;
 
@@ -503,10 +509,11 @@ export function useSettleAssertionAction({
       disabled: true,
     };
   }
-  // unique to settle, if we have an error preparing the transaction, this usually means the request has been settled
+  // unique to settle, if we have an error preparing the transaction,
+  // this means this is probably disputed, but no answer available from dvm yet
   if (prepareSettleAssertionError) {
     return {
-      title: settled,
+      title: disputed,
       disabled: true,
     };
   }

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -62,11 +62,11 @@ export type OracleQueryUI = {
   chainId: ChainId;
   chainName: ChainName;
   oracleType: OracleType;
-  project: Project;
-  title: ReactNode;
-  description: ReactNode;
-  expiryType: ExpiryType | null;
   oracleAddress: Address;
+  project: Project;
+  title?: ReactNode;
+  description?: ReactNode;
+  expiryType?: ExpiryType | null;
   // not always available with assertions
   identifier?: string;
   // price requests query text is the ancillary data
@@ -75,7 +75,7 @@ export type OracleQueryUI = {
   queryText?: string;
   // for price requests the value text is null until a price is proposed. Then it is the proposed price. After a price is settled it is the settled price.
   // for assertions the value text is null until settlement, after which it is the `settlementResolution` field
-  valueText: string | null;
+  valueText?: string | null;
   timeUTC?: string;
   timeUNIX?: number;
   timeMilliseconds?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2794,6 +2794,25 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.0"
 
+"@radix-ui/react-tooltip@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.0.5.tgz#fe20274aeac874db643717fc7761d5a8abdd62d1"
+  integrity sha512-cDKVcfzyO6PpckZekODJZDe5ZxZ2fCZlzKzTmPhe4mX9qTHRfLcKgqb0OKf22xLwDequ2tVleim+ZYx3rabD5w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.3"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-popper" "1.1.1"
+    "@radix-ui/react-portal" "1.0.2"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.2"
+    "@radix-ui/react-slot" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    "@radix-ui/react-visually-hidden" "1.0.2"
+
 "@radix-ui/react-use-callback-ref@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz#9e7b8b6b4946fe3cbe8f748c82a2cce54e7b6a90"
@@ -2846,6 +2865,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-visually-hidden@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.2.tgz#29b117a59ef09a984bdad12cb98d81e8350be450"
+  integrity sha512-qirnJxtYn73HEk1rXL12/mXnu2rwsNHDID10th2JGtdK25T9wX+mxRmGt7iPSahw512GbZOc0syZX1nLQGoEOg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.2"
 
 "@radix-ui/rect@1.0.0":
   version "1.0.0"


### PR DESCRIPTION
## motivation
settle button not showing up for verify tab which were expired.

## changes
testing this feature, ended up finding some more critical bugs:
1. updates to query state were not being reflected in panel - changed how panel references query state
2. once this was fixed, transactions in the action hook would loop infinitely, due to watching query state with transaction data, removed this dependency, but this may have unknown consequences
3. merged data from receipt would override previous data even if undefined, this was due to converters always exporting keys even when the values were undefined, causing overrides.  refactored converters to only return keys where data exists

finally the button is enabled now to "settle" when a vote had gone through liveness
![image](https://user-images.githubusercontent.com/4429761/229884769-e97659e2-8360-40d9-87ec-daa079b526fe.png)
