### PR TITLE
feat: add oraclev2 log updates

### DIFF
--- a/libs/src/clients/optimisticOracle/client.ts
+++ b/libs/src/clients/optimisticOracle/client.ts
@@ -3,6 +3,7 @@ import {
   OptimisticOracleInterfaceEthers__factory,
   getOptimisticOracleInterfaceAbi,
 } from "@uma/contracts-frontend";
+import { parseIdentifier } from "@libs/utils";
 import type { SignerOrProvider, GetEventType } from "@libs/types";
 import type { Event, BigNumberish, BigNumber } from "ethers";
 import { utils } from "ethers";
@@ -82,7 +83,7 @@ export function requestId(
 ): string {
   // this matches how we generate ids in the subgraph
   return [
-    request.identifier,
+    parseIdentifier(request.identifier),
     request.timestamp.toString(),
     request.ancillaryData,
   ].join("-");

--- a/libs/src/clients/optimisticOracleV2/client.ts
+++ b/libs/src/clients/optimisticOracleV2/client.ts
@@ -4,6 +4,7 @@ import {
   getOptimisticOracleV2InterfaceAbi,
 } from "@uma/contracts-frontend";
 import type { SignerOrProvider, GetEventType } from "@libs/types";
+import { parseIdentifier } from "@libs/utils";
 import type { Event, BigNumberish, BigNumber } from "ethers";
 import { utils } from "ethers";
 
@@ -74,6 +75,10 @@ export type Request = RequestKey &
     proposeBlockNumber: number;
     disputeBlockNumber: number;
     settleBlockNumber: number;
+    requestLogIndex: number;
+    proposeLogIndex: number;
+    disputeLogIndex: number;
+    settleLogIndex: number;
     requestSettings: RequestSettings;
   }>;
 
@@ -86,11 +91,10 @@ export function requestId(
 ): string {
   // if enabling sorting, put timestamp first
   return [
+    parseIdentifier(request.identifier),
     request.timestamp.toString(),
-    request.identifier,
-    request.requester,
     request.ancillaryData,
-  ].join("!");
+  ].join("-");
 }
 
 export function reduceEvents(state: EventState, event: Event): EventState {
@@ -122,6 +126,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Requested,
         requestTx: event.transactionHash,
         requestBlockNumber: event.blockNumber,
+        requestLogIndex: event.logIndex,
       };
       break;
     }
@@ -154,6 +159,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Proposed,
         proposeTx: event.transactionHash,
         proposeBlockNumber: event.blockNumber,
+        proposeLogIndex: event.logIndex,
       };
       break;
     }
@@ -184,6 +190,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Disputed,
         disputeTx: event.transactionHash,
         disputeBlockNumber: event.blockNumber,
+        disputeLogIndex: event.logIndex,
       };
       break;
     }
@@ -217,6 +224,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Settled,
         settleTx: event.transactionHash,
         settleBlockNumber: event.blockNumber,
+        settleLogIndex: event.logIndex,
       };
       break;
     }

--- a/libs/src/constants.ts
+++ b/libs/src/constants.ts
@@ -56,7 +56,7 @@ export const ContractInfoList: ContractInfoList = [
     // goerli
     type: "Optimistic Oracle V2",
     chainId: 5,
-    address: getAddress("0xc48F2d8491AffFc8eB21c85dEa1B4c0259c749a0"),
+    address: getAddress("0xA5B9d8a0B0Fa04Ba71BDD68069661ED5C0848884"),
   },
   {
     // optimism

--- a/libs/src/oracle-sdk-v1/services/optimisticOracleV2.ts
+++ b/libs/src/oracle-sdk-v1/services/optimisticOracleV2.ts
@@ -214,7 +214,15 @@ export class OptimisticOracleV2 implements OracleInterface {
     };
   }
   updateFromTransactionReceipt(receipt: TransactionReceipt): void {
-    const events = receipt.logs.map((log) => this.parseLog(log));
+    const events = receipt.logs
+      .map((log) => {
+        try {
+          return this.parseLog(log);
+        } catch (err) {
+          console.warn("Failed parsing log for oov2:", err);
+        }
+      })
+      .filter(Boolean);
     this.updateFromEvents(events as unknown[] as OptimisticOracleEvent[]);
   }
   listRequests(): Request[] {

--- a/libs/src/oracle-sdk-v2/services/index.ts
+++ b/libs/src/oracle-sdk-v2/services/index.ts
@@ -2,6 +2,7 @@ export * as oracle1Gql from "./oraclev1/gql";
 export * as oracle1Ethers from "./oraclev1/ethers";
 // oracle 2 is handled the same way as oracle 1
 export * as oracle2Gql from "./oraclev1/gql";
+export * as oracle2Ethers from "./oraclev2/ethers";
 // oracle skinny is same as oracle 1
 export * as oracle2SkinnyGql from "./oraclev1/gql";
 export * as oracle3Gql from "./oraclev3/gql";

--- a/libs/src/oracle-sdk-v2/services/oraclev2/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev2/ethers/factory.ts
@@ -1,0 +1,157 @@
+import Events from "events";
+import { ethers } from "ethers";
+import { assertAddress } from "@shared/utils";
+import { parseIdentifier } from "@libs/utils";
+import type {
+  Request as SharedRequest,
+  OracleType,
+  ChainId,
+  RequestState as SharedRequestState,
+} from "@shared/types";
+import type { Address } from "wagmi";
+import type {
+  Handlers,
+  Service,
+  ServiceFactory,
+} from "@libs/oracle-sdk-v2/types";
+import type { TransactionReceipt } from "@libs/types";
+import type { Request } from "@libs/clients/optimisticOracleV2";
+import { RequestState, requestId } from "@libs/clients/optimisticOracleV2";
+import { OptimisticOracleV2 } from "@libs/oracle-sdk-v1/services/optimisticOracleV2";
+
+export type Config = {
+  chainId: ChainId;
+  url: string;
+  address: string;
+};
+
+function convertToSharedState(state: RequestState): SharedRequestState {
+  if (state === RequestState.Invalid) return "Invalid";
+  if (state === RequestState.Requested) return "Requested";
+  if (state === RequestState.Proposed) return "Proposed";
+  if (state === RequestState.Expired) return "Expired";
+  if (state === RequestState.Disputed) return "Disputed";
+  if (state === RequestState.Resolved) return "Resolved";
+  return "Settled";
+}
+
+const ConvertToSharedRequest =
+  (chainId: ChainId, oracleAddress: Address, oracleType: OracleType) =>
+  (request: Request): SharedRequest => {
+    const {
+      requester,
+      identifier,
+      timestamp,
+      ancillaryData,
+      currency,
+      reward,
+      finalFee,
+      proposer,
+      proposedPrice,
+      expirationTime,
+      disputer,
+      price,
+      settleTx,
+      requestTx,
+      proposeTx,
+      disputeTx,
+      requestBlockNumber,
+      proposeBlockNumber,
+      disputeBlockNumber,
+      settleBlockNumber,
+      requestLogIndex,
+      proposeLogIndex,
+      disputeLogIndex,
+      settleLogIndex,
+      state,
+    } = request;
+    const id = requestId(request);
+
+    const result: SharedRequest = {
+      id,
+      chainId,
+      oracleAddress,
+      oracleType,
+      requester: assertAddress(requester),
+      identifier: parseIdentifier(identifier),
+      time: timestamp.toString(),
+      ancillaryData,
+    };
+    if (currency) result.currency = assertAddress(currency);
+    if (reward) result.reward = reward;
+    if (finalFee) result.finalFee = finalFee;
+    if (proposer) result.proposer = proposer;
+    if (proposedPrice) result.proposedPrice = proposedPrice;
+    if (expirationTime)
+      result.proposalExpirationTimestamp = expirationTime.toString();
+    if (disputer) result.disputer = disputer;
+    if (price) result.settlementPrice = price;
+    if (reward) result.settlementPayout = reward;
+    if (settleTx) result.settlementHash = settleTx;
+    if (requestBlockNumber)
+      result.requestBlockNumber = requestBlockNumber.toString();
+    if (requestTx) result.requestHash = requestTx;
+    if (price) result.settlementPrice = price;
+    if (reward) result.settlementPayout = reward;
+    if (settleTx) result.settlementHash = settleTx;
+    if (requestBlockNumber)
+      result.requestBlockNumber = requestBlockNumber.toString();
+    if (requestTx) result.requestHash = requestTx;
+    if (state) result.state = convertToSharedState(state);
+    if (proposeTx) result.proposalHash = proposeTx;
+    if (disputeTx) result.disputeHash = disputeTx;
+    if (proposeBlockNumber)
+      result.proposalBlockNumber = proposeBlockNumber.toString();
+    if (disputeBlockNumber)
+      result.disputeBlockNumber = disputeBlockNumber.toString();
+    if (requestLogIndex) result.requestLogIndex = requestLogIndex.toString();
+    if (proposeLogIndex) result.proposalLogIndex = proposeLogIndex.toString();
+    if (disputeLogIndex) result.disputeLogIndex = disputeLogIndex.toString();
+    if (settleBlockNumber)
+      result.settlementBlockNumber = settleBlockNumber.toString();
+    if (settleLogIndex) result.settlementLogIndex = settleLogIndex.toString();
+
+    // unable to get the following values, omit their keys to avoid
+    // overriding other sources when merged in final store
+    // dont know how this comes from events
+    // settlementRecipient: null
+    // settlementTimestamp: null,
+    // requestTimestamp: null,
+
+    return result;
+  };
+export type Api = {
+  updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
+};
+export const Factory = (config: Config): [ServiceFactory, Api] => {
+  const convertToSharedRequest = ConvertToSharedRequest(
+    config.chainId,
+    assertAddress(config.address),
+    "Optimistic Oracle V2"
+  );
+  const provider = new ethers.providers.JsonRpcProvider(config.url);
+  const oo = new OptimisticOracleV2(provider, config.address, config.chainId);
+  const events = new Events();
+  function updateFromTransactionReceipt(receipt: TransactionReceipt) {
+    try {
+      oo.updateFromTransactionReceipt(receipt);
+      const requests: Request[] = oo.listRequests();
+      const sharedRequests = requests.map((request) =>
+        convertToSharedRequest(request)
+      );
+      events.emit("requests", sharedRequests);
+    } catch (err) {
+      console.warn("Error updating oov2 from receipt:", err);
+    }
+  }
+  const service = (handlers: Handlers): Service => {
+    if (handlers.requests) events.on("requests", handlers.requests);
+  };
+
+  return [
+    service,
+    {
+      updateFromTransactionReceipt,
+    },
+  ];
+};

--- a/libs/src/oracle-sdk-v2/services/oraclev2/ethers/index.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev2/ethers/index.ts
@@ -1,0 +1,1 @@
+export * from "./factory";

--- a/libs/src/oracle-sdk-v2/services/oraclev2/index.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev2/index.ts
@@ -1,0 +1,1 @@
+export * as ethers from "./ethers";

--- a/libs/src/oracle-sdk-v2/services/oraclev3/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/ethers/factory.ts
@@ -110,7 +110,6 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
   );
   const provider = new ethers.providers.JsonRpcProvider(config.url);
   const contract = connect(config.address, provider);
-  // const oo = new OptimisticOracle(provider, config.address, config.chainId);
   const events = new Events();
 
   function parseLog(log: Log) {

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -47,6 +47,14 @@ const Env = ss.object({
   NEXT_PUBLIC_PROVIDER_V1_5: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_V1_10: ss.optional(ss.string()),
 
+  // enabling services for realtime updates oo v2
+  NEXT_PUBLIC_PROVIDER_V2_1: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V2_137: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V2_288: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V2_42161: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V2_5: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_V2_10: ss.optional(ss.string()),
+
   // enabling services for realtime updates oo v3
   NEXT_PUBLIC_PROVIDER_V3_1: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_V3_137: ss.optional(ss.string()),
@@ -104,6 +112,12 @@ const env = ss.create(
     NEXT_PUBLIC_PROVIDER_V1_42161: process.env.NEXT_PUBLIC_PROVIDER_V1_42161,
     NEXT_PUBLIC_PROVIDER_V1_5: process.env.NEXT_PUBLIC_PROVIDER_V1_5,
     NEXT_PUBLIC_PROVIDER_V1_10: process.env.NEXT_PUBLIC_PROVIDER_V1_10,
+    NEXT_PUBLIC_PROVIDER_V2_1: process.env.NEXT_PUBLIC_PROVIDER_V2_1,
+    NEXT_PUBLIC_PROVIDER_V2_137: process.env.NEXT_PUBLIC_PROVIDER_V2_137,
+    NEXT_PUBLIC_PROVIDER_V2_288: process.env.NEXT_PUBLIC_PROVIDER_V2_288,
+    NEXT_PUBLIC_PROVIDER_V2_42161: process.env.NEXT_PUBLIC_PROVIDER_V2_42161,
+    NEXT_PUBLIC_PROVIDER_V2_5: process.env.NEXT_PUBLIC_PROVIDER_V2_5,
+    NEXT_PUBLIC_PROVIDER_V2_10: process.env.NEXT_PUBLIC_PROVIDER_V2_10,
     NEXT_PUBLIC_PROVIDER_V3_1: process.env.NEXT_PUBLIC_PROVIDER_V3_1,
     NEXT_PUBLIC_PROVIDER_V3_137: process.env.NEXT_PUBLIC_PROVIDER_V3_137,
     NEXT_PUBLIC_PROVIDER_V3_288: process.env.NEXT_PUBLIC_PROVIDER_V3_288,
@@ -575,6 +589,72 @@ function parseEnv(env: Env): Config {
       address: getContractAddress({
         chainId: 10,
         type: "Optimistic Oracle V1",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V2_1) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V2",
+      url: env.NEXT_PUBLIC_PROVIDER_V2_1,
+      chainId: 1,
+      address: getContractAddress({ chainId: 1, type: "Optimistic Oracle V2" }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V2_137) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V2",
+      url: env.NEXT_PUBLIC_PROVIDER_V2_137,
+      chainId: 137,
+      address: getContractAddress({
+        chainId: 137,
+        type: "Optimistic Oracle V2",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V2_288) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V2",
+      url: env.NEXT_PUBLIC_PROVIDER_V2_288,
+      chainId: 288,
+      address: getContractAddress({
+        chainId: 288,
+        type: "Optimistic Oracle V2",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V2_42161) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V2",
+      url: env.NEXT_PUBLIC_PROVIDER_V2_42161,
+      chainId: 42161,
+      address: getContractAddress({
+        chainId: 42161,
+        type: "Optimistic Oracle V2",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V2_5) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V2",
+      url: env.NEXT_PUBLIC_PROVIDER_V2_5,
+      chainId: 5,
+      address: getContractAddress({ chainId: 5, type: "Optimistic Oracle V2" }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_V2_10) {
+    providers.push({
+      source: "provider",
+      type: "Optimistic Oracle V2",
+      url: env.NEXT_PUBLIC_PROVIDER_V2_10,
+      chainId: 10,
+      address: getContractAddress({
+        chainId: 10,
+        type: "Optimistic Oracle V2",
       }),
     });
   }

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -11,6 +11,7 @@ import { Client } from "@libs/oracle-sdk-v2";
 import {
   oracles,
   oracle1Ethers,
+  oracle2Ethers,
   oracle3Ethers,
 } from "@libs/oracle-sdk-v2/services";
 import type { Api } from "@libs/oracle-sdk-v2/services/oraclev1/ethers";
@@ -41,6 +42,8 @@ const [oracleEthersServices, oracleEthersApis] = config.providers
   .map((config): [ProviderConfig, ServiceFactory, Api] => {
     if (config.type === "Optimistic Oracle V1")
       return [config, ...oracle1Ethers.Factory(config)];
+    if (config.type === "Optimistic Oracle V2")
+      return [config, ...oracle2Ethers.Factory(config)];
     if (config.type === "Optimistic Oracle V3")
       return [config, ...oracle3Ethers.Factory(config)];
     throw new Error(


### PR DESCRIPTION
## motivation
we want to be able to update the state of each oracle v2 request when user submits transactions

## changes
this adds oracle v2 receipt parsing when transactions complete, and updates global state of oracle data.  the logic is nearly identical to oracle v1 work, but i've separated it out as a different service to keep it easy to reason about. 

this also fixes a couple other issues
- identifying data in global state when its coming from a tx receipt is now fixed for oracle v1 requests
- wrong goerli address constant, we should probably verify all the constants eventually