### PR TITLE
fix: panel infinite loop

### DIFF
--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -134,7 +134,7 @@ export function Panel() {
 
     setMessage(message);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, primaryAction, content]);
+  }, [page, primaryAction]);
 
   function getActionsTitle() {
     if (page === "settled") return "Settled as";

--- a/src/hooks/handleQueryInUrl.ts
+++ b/src/hooks/handleQueryInUrl.ts
@@ -28,8 +28,9 @@ export function useHandleQueryInUrl() {
       void openPanel(query, false);
 
       async function redirectToCorrectPage() {
+        const pathname = `/${pageForQuery === "verify" ? "" : pageForQuery}`;
         await router.push({
-          pathname: `/${pageForQuery}`,
+          pathname,
           query: router.query,
         });
       }


### PR DESCRIPTION
We were running the message generating logic when the `content` changed. This is redundant and can lead to an infinite loop, because of how react stores references in memory (they can move around)