### PR TITLE
handle entries number changing

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -58,7 +58,26 @@ export function Pagination<Entry>({
 
     setPageNumber(newPageNumber);
     updateEntries({ newPageNumber });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [findIndex, resultsPerPage, entries]);
+
+  useEffect(() => {
+    if (entries.length === 0) {
+      setPageNumber(1);
+      updateEntries();
+      return;
+    }
+
+    const newNumberOfPages = Math.ceil(entries.length / resultsPerPage);
+    if (pageNumber > newNumberOfPages) {
+      const newPageNumber = newNumberOfPages;
+      setPageNumber(newPageNumber);
+      updateEntries({ newPageNumber });
+    } else {
+      updateEntries();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entries, resultsPerPage]);
 
   function getNumberOfButtons() {
     if (numberOfPages === defaultNumberOfButtons + 1) {


### PR DESCRIPTION
Handle the case where the list of entries gets shorter, ensuring that the pagination component stays consistent with the updated entries.

- If the new entries list is empty, set the page number to 1 and update the entries to show.
- Calculate the new number of pages based on the updated entries and the current resultsPerPage.
- If the current page number is greater than the new number of pages, set the page number to the new last page, and update the entries to show.
- If the current page number is still valid, just update the entries to show without changing the page number.