### PR TITLE
feat: add isOptimisticGovernor option to ui query

### DIFF
--- a/shared/constants/abi.ts
+++ b/shared/constants/abi.ts
@@ -179,3 +179,19 @@ export const settleAssertionAbi = [
     type: "function",
   },
 ];
+
+export const ogAbi = [
+  {
+    inputs: [],
+    name: "rules",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+];

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -76,6 +76,13 @@ function convertToSolidityRequest(request: RequiredRequest): SolidityRequest {
   };
 }
 
+export function isOptimisticGovernor(decodedAncillaryData: string) {
+  return (
+    decodedAncillaryData.includes("rules:") &&
+    decodedAncillaryData.includes("explanation:")
+  );
+}
+
 export function utf8ToHex(utf8String: string) {
   return ethers.utils.hexlify(ethers.utils.toUtf8Bytes(utf8String));
 }
@@ -672,6 +679,7 @@ export function requestToOracleQuery(request: Request): OracleQueryUI {
   if (exists(ancillaryData)) {
     result.queryTextHex = ancillaryData;
     result.queryText = safeDecodeHexString(ancillaryData);
+    result.isOptimisticGovernor = isOptimisticGovernor(result.queryText);
   }
 
   let bytes32Identifier = undefined;
@@ -871,6 +879,7 @@ export function assertionToOracleQuery(assertion: Assertion): OracleQueryUI {
     result.queryText = safeDecodeHexString(claim);
     result.title = result.queryText;
     result.description = result.queryText;
+    result.isOptimisticGovernor = isOptimisticGovernor(result.queryText);
   }
   if (exists(currency)) {
     result.tokenAddress = currency;

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -120,6 +120,7 @@ export type OracleQueryUI = {
   settlementTimestamp?: string | null;
   settlementHash?: string | null;
   settlementLogIndex?: string | null;
+  isOptimisticGovernor?: boolean;
 };
 
 export type ApproveBondSpendParams = {


### PR DESCRIPTION
## motivation
we want the ability to know if we have an og request, so that in the future we can show this in the ui

## changes
this adds the og abi in case we need to use it, currently its unused, since we can determine if its an og request by parsing ancillary data, to look for "rules:" and "explanation:".  this is not totally bulletproof but should get the job done. future implementations may require querying the og contract.   use the `isOptimisticGovernor` flag to add filters or badges in the UI. 