### PR TITLE
feat: add information icons

### DIFF
--- a/src/components/InformationIcon.tsx
+++ b/src/components/InformationIcon.tsx
@@ -1,0 +1,12 @@
+import Info from "public/assets/icons/info.svg";
+import styled from "styled-components";
+
+export function InformationIcon() {
+  return (
+    <Button>
+      <Info />
+    </Button>
+  );
+}
+
+const Button = styled.button``;

--- a/src/components/InformationIcon.tsx
+++ b/src/components/InformationIcon.tsx
@@ -1,12 +1,25 @@
+import { Tooltip } from "@/components";
 import Info from "public/assets/icons/info.svg";
+import type { ReactNode } from "react";
+import { useState } from "react";
 import styled from "styled-components";
 
-export function InformationIcon() {
+interface Props {
+  content: ReactNode;
+}
+export function InformationIcon({ content }: Props) {
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
   return (
-    <Button>
-      <Info />
-    </Button>
+    <Tooltip content={content} open={tooltipOpen} onOpenChange={setTooltipOpen}>
+      <Button onClick={() => setTooltipOpen(true)}>
+        <Info />
+      </Button>
+    </Tooltip>
   );
 }
 
-const Button = styled.button``;
+const Button = styled.button`
+  display: inline-block;
+  margin-left: 8px;
+`;

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -121,14 +121,14 @@ export function Panel() {
       <>
         This query has already been {alreadyProposed ? "proposed" : "settled"}.
         View it{" "}
-        <Link
+        <MessageLink
           href={{
             pathname: alreadyProposed ? "/" : "/settled",
             query: makeUrlParamsForQuery(content),
           }}
         >
           here.
-        </Link>
+        </MessageLink>
       </>
     );
 
@@ -165,12 +165,12 @@ export function Panel() {
       <br />
       <p>The minimum bond is the final fee for a given bond token.</p>
       <br />
-      <Link
+      <MessageLink
         href="https://docs.uma.xyz/developers/setting-custom-bond-and-liveness-parameters"
         target="_blank"
       >
         Learn more
-      </Link>
+      </MessageLink>
     </>
   );
 
@@ -187,12 +187,12 @@ export function Panel() {
         mollitia!
       </p>
       <br />
-      <Link
+      <MessageLink
         href="https://docs.uma.xyz/developers/setting-custom-bond-and-liveness-parameters"
         target="_blank"
       >
         Learn more
-      </Link>
+      </MessageLink>
     </>
   );
 
@@ -207,12 +207,12 @@ export function Panel() {
       <br />
       <p>A typical liveness window is two hours.</p>
       <br />
-      <Link
+      <MessageLink
         href="https://docs.uma.xyz/developers/setting-custom-bond-and-liveness-parameters"
         target="_blank"
       >
         Learn more
-      </Link>
+      </MessageLink>
     </>
   );
 
@@ -552,6 +552,7 @@ const MessageText = styled(Text)`
 
 const Link = styled(NextLink)`
   font: var(--body-sm);
+  font-size: inherit;
   text-decoration: none;
   color: var(--red-500);
   transition: opacity var(--animation-duration);
@@ -560,6 +561,11 @@ const Link = styled(NextLink)`
   &:hover {
     opacity: 0.75;
   }
+`;
+
+// we don't want to word-break the link in the message text
+const MessageLink = styled(Link)`
+  word-break: normal;
 `;
 
 // icons

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -4,6 +4,7 @@ import {
   ConnectButton,
   Currency,
   DecimalInput,
+  InformationIcon,
   PanelBase,
 } from "@/components";
 import {
@@ -26,7 +27,6 @@ import {
 } from "@/hooks";
 import NextLink from "next/link";
 import AncillaryData from "public/assets/icons/ancillary-data.svg";
-import Info from "public/assets/icons/info.svg";
 import Pencil from "public/assets/icons/pencil.svg";
 import Settled from "public/assets/icons/settled.svg";
 import Timestamp from "public/assets/icons/timestamp.svg";
@@ -154,6 +154,68 @@ export function Panel() {
     void closePanel();
   }
 
+  // todo: @sean update copy
+  const bondInformation = (
+    <>
+      <p>
+        Every request to UMA&apos;s Optimistic Oracle includes bond settings
+        that specify the size of the bond that proposers (and disputers) are
+        required to post.
+      </p>
+      <br />
+      <p>The minimum bond is the final fee for a given bond token.</p>
+      <br />
+      <Link
+        href="https://docs.uma.xyz/developers/setting-custom-bond-and-liveness-parameters"
+        target="_blank"
+      >
+        Learn more
+      </Link>
+    </>
+  );
+
+  // todo: @sean update copy
+  const rewardInformation = (
+    <>
+      <p>
+        Lorem ipsum dolor sit, amet consectetur adipisicing elit. Illum, beatae.
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quod.
+      </p>
+      <br />
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Blanditiis,
+        mollitia!
+      </p>
+      <br />
+      <Link
+        href="https://docs.uma.xyz/developers/setting-custom-bond-and-liveness-parameters"
+        target="_blank"
+      >
+        Learn more
+      </Link>
+    </>
+  );
+
+  // todo: @sean update copy
+  const livenessInformation = (
+    <>
+      <p>
+        Every request to UMA&apos;s Optimistic Oracle includes liveness settings
+        that specify the liveness window, which is the challenge period during
+        which a proposal can be challenged.
+      </p>
+      <br />
+      <p>A typical liveness window is two hours.</p>
+      <br />
+      <Link
+        href="https://docs.uma.xyz/developers/setting-custom-bond-and-liveness-parameters"
+        target="_blank"
+      >
+        Learn more
+      </Link>
+    </>
+  );
+
   return (
     <PanelBase panelOpen={panelOpen} closePanel={close}>
       <TitleWrapper>
@@ -197,7 +259,7 @@ export function Panel() {
             <ActionWrapper>
               <ActionText>
                 Bond
-                <InfoIcon />
+                <InformationIcon content={bondInformation} />
               </ActionText>
               <ActionText>
                 <Currency
@@ -211,7 +273,7 @@ export function Panel() {
               <ActionWrapper>
                 <ActionText>
                   Reward
-                  <InfoIcon />
+                  <InformationIcon content={rewardInformation} />
                 </ActionText>
                 <ActionText>
                   <Currency
@@ -225,7 +287,7 @@ export function Panel() {
             <ActionWrapper>
               <ActionText>
                 Challenge period ends in
-                <InfoIcon />
+                <InformationIcon content={livenessInformation} />
               </ActionText>
               <ActionText>{formattedLivenessEndsIn}</ActionText>
             </ActionWrapper>
@@ -503,11 +565,6 @@ const Link = styled(NextLink)`
 // icons
 
 const PencilIcon = styled(Pencil)``;
-
-const InfoIcon = styled(Info)`
-  display: inline-block;
-  margin-left: 8px;
-`;
 
 const TimestampIcon = styled(Timestamp)``;
 

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -5,11 +5,13 @@ import styled, { keyframes } from "styled-components";
 interface Props {
   children: ReactNode;
   content: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
-export function Tooltip({ children, content }: Props) {
+export function Tooltip({ children, content, open, onOpenChange }: Props) {
   return (
     <RadixTooltip.Provider delayDuration={100}>
-      <RadixTooltip.Root>
+      <RadixTooltip.Root open={open} onOpenChange={onOpenChange}>
         <TriggerWrapper asChild>
           <Trigger>{children}</Trigger>
         </TriggerWrapper>

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -71,6 +71,7 @@ const slideLeftAndFade = keyframes`
 `;
 
 const Content = styled(RadixTooltip.Content)`
+  z-index: 2;
   max-width: 400px;
   padding: 20px;
   font: var(--body-sm);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,6 +12,7 @@ export { GlobalStyle } from "./GlobalStyle";
 export { ConnectButton } from "./Header/ConnectButton";
 export { Header } from "./Header/Header";
 export { IconWrapper } from "./IconWrapper";
+export { InformationIcon } from "./InformationIcon";
 export { Layout } from "./Layout";
 export { LoadingSpinner } from "./LoadingSpinner";
 export { NoQueries } from "./NoQueries";

--- a/src/stories/InformationIcon.stories.tsx
+++ b/src/stories/InformationIcon.stories.tsx
@@ -1,0 +1,29 @@
+import { InformationIcon } from "@/components";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta = {
+  component: InformationIcon,
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: "100%",
+          height: "100vh",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof InformationIcon>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/stories/InformationIcon.stories.tsx
+++ b/src/stories/InformationIcon.stories.tsx
@@ -14,6 +14,7 @@ const meta: Meta = {
           alignItems: "center",
         }}
       >
+        <p>This is some text that warrants further explanation</p>
         <Story />
       </div>
     ),
@@ -25,5 +26,7 @@ export default meta;
 type Story = StoryObj<typeof InformationIcon>;
 
 export const Default: Story = {
-  args: {},
+  args: {
+    content: "This is some information",
+  },
 };


### PR DESCRIPTION
Add an `InformationIcon` component that can be dropped in to text content that needs further information.

This component wraps a tooltip and takes tooltip content as a prop.

It also wraps a button which shows the tooltip when clicked — this is so that on mobile (where hover events don't fire) the user can click the icon and still see the information.

[Story](https://63d101d13121a53332f6218c-yxryujdwnx.chromatic.com/?path=/story/stories-informationicon--default)

See it in action in the [Panel story](https://63d101d13121a53332f6218c-yxryujdwnx.chromatic.com/?path=/story/stories-panel--verify-with-dispute)