### PR TITLE
fix: query graph calls by time descending so we see newest

### DIFF
--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
@@ -13,7 +13,7 @@ export async function getPriceRequests<Query extends PriceRequestsQuery>(
   const isV2 = oracleType === "Optimistic Oracle V2";
   const query = gql`
     query ${queryName} {
-      optimisticPriceRequests {
+      optimisticPriceRequests(orderBy: time, orderDirection: desc, first:500) {
         id
         identifier
         ancillaryData


### PR DESCRIPTION
## motivation
we are missing some newish requests 

## changes
this orders requests by time descending, and only grabs the first 500 since the request tends to take a long time.

this does not apply to v3 assertions because there's no good value afaik to sort on