### PR TITLE
feat: add skinny oo transaction handlers

### DIFF
--- a/libs/src/clients/skinnyOptimisticOracle/client.ts
+++ b/libs/src/clients/skinnyOptimisticOracle/client.ts
@@ -69,6 +69,10 @@ export type Request = RequestKey &
     proposeBlockNumber: number;
     disputeBlockNumber: number;
     settleBlockNumber: number;
+    requestLogIndex: number;
+    proposeLogIndex: number;
+    disputeLogIndex: number;
+    settleLogIndex: number;
   }>;
 
 export interface EventState {
@@ -105,6 +109,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Requested,
         requestTx: event.transactionHash,
         requestBlockNumber: event.blockNumber,
+        requestLogIndex: event.logIndex,
       };
       break;
     }
@@ -124,6 +129,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Proposed,
         proposeTx: event.transactionHash,
         proposeBlockNumber: event.blockNumber,
+        proposeLogIndex: event.logIndex,
       };
       break;
     }
@@ -143,6 +149,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Disputed,
         disputeTx: event.transactionHash,
         disputeBlockNumber: event.blockNumber,
+        disputeLogIndex: event.logIndex,
       };
       break;
     }
@@ -162,6 +169,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
         state: RequestState.Settled,
         settleTx: event.transactionHash,
         settleBlockNumber: event.blockNumber,
+        settleLogIndex: event.logIndex,
       };
       break;
     }

--- a/libs/src/constants.ts
+++ b/libs/src/constants.ts
@@ -125,6 +125,16 @@ export const ContractInfoList: ContractInfoList = [
     chainId: 1,
     address: getAddress("0xeE3Afe347D5C74317041E2618C49534dAf887c24"),
   },
+  {
+    type: "Skinny Optimistic Oracle",
+    chainId: 5,
+    address: getAddress("0xeDc52A961B5Ca2AC7B2e0bc36714dB60E5a115Ab"),
+  },
+  {
+    type: "Skinny Optimistic Oracle V2",
+    chainId: 5,
+    address: getAddress("0x5a9Ed5DaC741e20cA6587d0c5C39C0992Db305C1"),
+  },
 ];
 export function getContractInfo(params: {
   chainId: number;

--- a/libs/src/oracle-sdk-v1/services/optimisticOracleV2.ts
+++ b/libs/src/oracle-sdk-v1/services/optimisticOracleV2.ts
@@ -220,6 +220,7 @@ export class OptimisticOracleV2 implements OracleInterface {
           return this.parseLog(log);
         } catch (err) {
           console.warn("Failed parsing log for oov2:", err);
+          return undefined;
         }
       })
       .filter(Boolean);

--- a/libs/src/oracle-sdk-v1/services/skinnyOptimisticOracle.ts
+++ b/libs/src/oracle-sdk-v1/services/skinnyOptimisticOracle.ts
@@ -223,7 +223,16 @@ export class SkinnyOptimisticOracle implements OracleInterface {
     };
   }
   updateFromTransactionReceipt(receipt: TransactionReceipt): void {
-    const events = receipt.logs.map((log) => this.parseLog(log));
+    const events = receipt.logs
+      .map((log) => {
+        try {
+          return this.parseLog(log);
+        } catch (err) {
+          console.warn("Failed parsing log for skinny oo:", err);
+          return undefined;
+        }
+      })
+      .filter(Boolean);
     this.updateFromEvents(events as unknown[] as OptimisticOracleEvent[]);
   }
   listRequests(): Request[] {

--- a/libs/src/oracle-sdk-v1/types/interfaces.ts
+++ b/libs/src/oracle-sdk-v1/types/interfaces.ts
@@ -43,6 +43,10 @@ export type Request = RequestKey & {
     proposeBlockNumber: number;
     disputeBlockNumber: number;
     settleBlockNumber: number;
+    requestLogIndex: number;
+    proposeLogIndex: number;
+    disputeLogIndex: number;
+    settleLogIndex: number;
     // oo v2 fields moved here from settings object
     bond: BigNumber;
     customLiveness: BigNumber;

--- a/libs/src/oracle-sdk-v2/services/index.ts
+++ b/libs/src/oracle-sdk-v2/services/index.ts
@@ -1,5 +1,6 @@
 export * as oracle1Gql from "./oraclev1/gql";
 export * as oracle1Ethers from "./oraclev1/ethers";
+export * as skinny1Ethers from "./skinnyv1/ethers";
 // oracle 2 is handled the same way as oracle 1
 export * as oracle2Gql from "./oraclev1/gql";
 export * as oracle2Ethers from "./oraclev2/ethers";

--- a/libs/src/oracle-sdk-v2/services/skinnyv1/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/skinnyv1/ethers/factory.ts
@@ -1,0 +1,161 @@
+import Events from "events";
+import { ethers } from "ethers";
+import { assertAddress } from "@shared/utils";
+import { parseIdentifier } from "@libs/utils";
+import type {
+  Request as SharedRequest,
+  OracleType,
+  ChainId,
+  RequestState as SharedRequestState,
+} from "@shared/types";
+import type { Address } from "wagmi";
+import type {
+  Handlers,
+  Service,
+  ServiceFactory,
+} from "@libs/oracle-sdk-v2/types";
+import type { TransactionReceipt } from "@libs/types";
+import type { Request } from "@libs/oracle-sdk-v1/types/interfaces";
+import { RequestState, requestId } from "@libs/clients/skinnyOptimisticOracle";
+import { SkinnyOptimisticOracle } from "@libs/oracle-sdk-v1/services/skinnyOptimisticOracle";
+
+export type Config = {
+  chainId: ChainId;
+  url: string;
+  address: string;
+};
+
+function convertToSharedState(state: RequestState): SharedRequestState {
+  if (state === RequestState.Invalid) return "Invalid";
+  if (state === RequestState.Requested) return "Requested";
+  if (state === RequestState.Proposed) return "Proposed";
+  if (state === RequestState.Expired) return "Expired";
+  if (state === RequestState.Disputed) return "Disputed";
+  if (state === RequestState.Resolved) return "Resolved";
+  return "Settled";
+}
+
+const ConvertToSharedRequest =
+  (chainId: ChainId, oracleAddress: Address, oracleType: OracleType) =>
+  (request: Request): SharedRequest => {
+    const {
+      requester,
+      identifier,
+      timestamp,
+      ancillaryData,
+      currency,
+      reward,
+      finalFee,
+      proposer,
+      proposedPrice,
+      expirationTime,
+      disputer,
+      price,
+      settleTx,
+      requestTx,
+      proposeTx,
+      disputeTx,
+      requestBlockNumber,
+      proposeBlockNumber,
+      disputeBlockNumber,
+      settleBlockNumber,
+      requestLogIndex,
+      proposeLogIndex,
+      disputeLogIndex,
+      settleLogIndex,
+      state,
+    } = request;
+    const id = requestId(request);
+
+    const result: SharedRequest = {
+      id,
+      chainId,
+      oracleAddress,
+      oracleType,
+      requester: assertAddress(requester),
+      identifier: parseIdentifier(identifier),
+      time: timestamp.toString(),
+      ancillaryData,
+    };
+    if (currency) result.currency = assertAddress(currency);
+    if (reward) result.reward = reward;
+    if (finalFee) result.finalFee = finalFee;
+    if (proposer) result.proposer = proposer;
+    if (proposedPrice) result.proposedPrice = proposedPrice;
+    if (expirationTime)
+      result.proposalExpirationTimestamp = expirationTime.toString();
+    if (disputer) result.disputer = disputer;
+    if (price) result.settlementPrice = price;
+    if (reward) result.settlementPayout = reward;
+    if (settleTx) result.settlementHash = settleTx;
+    if (requestBlockNumber)
+      result.requestBlockNumber = requestBlockNumber.toString();
+    if (requestTx) result.requestHash = requestTx;
+    if (price) result.settlementPrice = price;
+    if (reward) result.settlementPayout = reward;
+    if (settleTx) result.settlementHash = settleTx;
+    if (requestBlockNumber)
+      result.requestBlockNumber = requestBlockNumber.toString();
+    if (requestTx) result.requestHash = requestTx;
+    if (state) result.state = convertToSharedState(state);
+    if (proposeTx) result.proposalHash = proposeTx;
+    if (disputeTx) result.disputeHash = disputeTx;
+    if (proposeBlockNumber)
+      result.proposalBlockNumber = proposeBlockNumber.toString();
+    if (disputeBlockNumber)
+      result.disputeBlockNumber = disputeBlockNumber.toString();
+    if (requestLogIndex) result.requestLogIndex = requestLogIndex.toString();
+    if (proposeLogIndex) result.proposalLogIndex = proposeLogIndex.toString();
+    if (disputeLogIndex) result.disputeLogIndex = disputeLogIndex.toString();
+    if (settleBlockNumber)
+      result.settlementBlockNumber = settleBlockNumber.toString();
+    if (settleLogIndex) result.settlementLogIndex = settleLogIndex.toString();
+
+    // unable to get the following values, omit their keys to avoid
+    // overriding other sources when merged in final store
+    // dont know how this comes from events
+    // settlementRecipient: null
+    // settlementTimestamp: null,
+    // requestTimestamp: null,
+
+    return result;
+  };
+export type Api = {
+  updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
+};
+export const Factory = (config: Config): [ServiceFactory, Api] => {
+  const convertToSharedRequest = ConvertToSharedRequest(
+    config.chainId,
+    assertAddress(config.address),
+    "Skinny Optimistic Oracle"
+  );
+  const provider = new ethers.providers.JsonRpcProvider(config.url);
+  const oo = new SkinnyOptimisticOracle(
+    provider,
+    config.address,
+    config.chainId
+  );
+  const events = new Events();
+  function updateFromTransactionReceipt(receipt: TransactionReceipt) {
+    try {
+      oo.updateFromTransactionReceipt(receipt);
+      const requests: Request[] = oo.listRequests();
+      const sharedRequests = requests.map((request) =>
+        convertToSharedRequest(request)
+      );
+      events.emit("requests", sharedRequests);
+    } catch (err) {
+      console.warn("Error updating skinny v1 from receipt:", err);
+    }
+  }
+  const service = (handlers: Handlers): Service => {
+    if (handlers.requests) events.on("requests", handlers.requests);
+  };
+
+  return [
+    service,
+    {
+      updateFromTransactionReceipt,
+    },
+  ];
+};

--- a/libs/src/oracle-sdk-v2/services/skinnyv1/ethers/index.ts
+++ b/libs/src/oracle-sdk-v2/services/skinnyv1/ethers/index.ts
@@ -1,0 +1,1 @@
+export * from "./factory";

--- a/libs/src/oracle-sdk-v2/services/skinnyv1/index.ts
+++ b/libs/src/oracle-sdk-v2/services/skinnyv1/index.ts
@@ -1,2 +1,1 @@
-export * as gql from "./gql";
 export * as ethers from "./ethers";

--- a/shared/constants/oracle.ts
+++ b/shared/constants/oracle.ts
@@ -5,6 +5,7 @@ export const oracleTypes = [
   "Optimistic Oracle V2",
   "Optimistic Oracle V3",
   "Skinny Optimistic Oracle",
+  "Skinny Optimistic Oracle V2",
 ] as const;
 
 export const expiryTypes = ["Event-based", "Time-based"] as const;

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -62,6 +62,13 @@ const Env = ss.object({
   NEXT_PUBLIC_PROVIDER_V3_42161: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_V3_5: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_V3_10: ss.optional(ss.string()),
+
+  NEXT_PUBLIC_PROVIDER_SKINNY_1: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_SKINNY_10: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_SKINNY_137: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_SKINNY_288: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_SKINNY_42161: ss.optional(ss.string()),
+  NEXT_PUBLIC_PROVIDER_SKINNY_5: ss.optional(ss.string()),
   // not supported yet
   // NEXT_PUBLIC_PROVIDER_V1_416: ss.optional(ss.string()),
   // NEXT_PUBLIC_PROVIDER_V1_43114: ss.optional(ss.string()),
@@ -124,6 +131,15 @@ const env = ss.create(
     NEXT_PUBLIC_PROVIDER_V3_42161: process.env.NEXT_PUBLIC_PROVIDER_V3_42161,
     NEXT_PUBLIC_PROVIDER_V3_5: process.env.NEXT_PUBLIC_PROVIDER_V3_5,
     NEXT_PUBLIC_PROVIDER_V3_10: process.env.NEXT_PUBLIC_PROVIDER_V3_10,
+    NEXT_PUBLIC_PROVIDER_SKINNY_1: process.env.NEXT_PUBLIC_PROVIDER_SKINNY_1,
+    NEXT_PUBLIC_PROVIDER_SKINNY_137:
+      process.env.NEXT_PUBLIC_PROVIDER_SKINNY_137,
+    NEXT_PUBLIC_PROVIDER_SKINNY_288:
+      process.env.NEXT_PUBLIC_PROVIDER_SKINNY_288,
+    NEXT_PUBLIC_PROVIDER_SKINNY_42161:
+      process.env.NEXT_PUBLIC_PROVIDER_SKINNY_42161,
+    NEXT_PUBLIC_PROVIDER_SKINNY_5: process.env.NEXT_PUBLIC_PROVIDER_SKINNY_5,
+    NEXT_PUBLIC_PROVIDER_SKINNY_10: process.env.NEXT_PUBLIC_PROVIDER_SKINNY_10,
     // not supported yet
     // NEXT_PUBLIC_PROVIDER_V1_416:   process.env.NEXT_PUBLIC_PROVIDER_V1_416,
     // NEXT_PUBLIC_PROVIDER_V1_43114: process.env.NEXT_PUBLIC_PROVIDER_V1_43114,
@@ -454,78 +470,6 @@ function parseEnv(env: Env): Config {
       }),
     });
   }
-  if (env.NEXT_PUBLIC_SUBGRAPH_SKINNY_1) {
-    subgraphs.push({
-      source: "gql",
-      url: env.NEXT_PUBLIC_SUBGRAPH_SKINNY_1,
-      type: "Skinny Optimistic Oracle",
-      chainId: 1,
-      address: getContractAddress({
-        chainId: 1,
-        type: "Skinny Optimistic Oracle",
-      }),
-    });
-  }
-  if (env.NEXT_PUBLIC_SUBGRAPH_SKINNY_10) {
-    subgraphs.push({
-      source: "gql",
-      url: env.NEXT_PUBLIC_SUBGRAPH_SKINNY_10,
-      type: "Skinny Optimistic Oracle",
-      chainId: 10,
-      address: getContractAddress({
-        chainId: 10,
-        type: "Skinny Optimistic Oracle",
-      }),
-    });
-  }
-  if (env.NEXT_PUBLIC_SUBGRAPH_SKINNY_137) {
-    subgraphs.push({
-      source: "gql",
-      url: env.NEXT_PUBLIC_SUBGRAPH_SKINNY_137,
-      type: "Skinny Optimistic Oracle",
-      chainId: 137,
-      address: getContractAddress({
-        chainId: 137,
-        type: "Skinny Optimistic Oracle",
-      }),
-    });
-  }
-  if (env.NEXT_PUBLIC_SUBGRAPH_SKINNY_288) {
-    subgraphs.push({
-      source: "gql",
-      url: env.NEXT_PUBLIC_SUBGRAPH_SKINNY_288,
-      type: "Skinny Optimistic Oracle",
-      chainId: 288,
-      address: getContractAddress({
-        chainId: 288,
-        type: "Skinny Optimistic Oracle",
-      }),
-    });
-  }
-  if (env.NEXT_PUBLIC_SUBGRAPH_SKINNY_42161) {
-    subgraphs.push({
-      source: "gql",
-      url: env.NEXT_PUBLIC_SUBGRAPH_SKINNY_42161,
-      type: "Skinny Optimistic Oracle",
-      chainId: 42161,
-      address: getContractAddress({
-        chainId: 42161,
-        type: "Skinny Optimistic Oracle",
-      }),
-    });
-  }
-  if (env.NEXT_PUBLIC_SUBGRAPH_SKINNY_5) {
-    subgraphs.push({
-      source: "gql",
-      url: env.NEXT_PUBLIC_SUBGRAPH_SKINNY_5,
-      type: "Skinny Optimistic Oracle",
-      chainId: 5,
-      address: getContractAddress({
-        chainId: 5,
-        type: "Skinny Optimistic Oracle",
-      }),
-    });
-  }
   if (env.NEXT_PUBLIC_PROVIDER_V1_1) {
     providers.push({
       source: "provider",
@@ -721,6 +665,78 @@ function parseEnv(env: Env): Config {
       address: getContractAddress({
         chainId: 10,
         type: "Optimistic Oracle V3",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_SKINNY_1) {
+    providers.push({
+      source: "provider",
+      type: "Skinny Optimistic Oracle",
+      url: env.NEXT_PUBLIC_PROVIDER_SKINNY_1,
+      chainId: 1,
+      address: getContractAddress({
+        chainId: 1,
+        type: "Skinny Optimistic Oracle",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_SKINNY_137) {
+    providers.push({
+      source: "provider",
+      type: "Skinny Optimistic Oracle",
+      url: env.NEXT_PUBLIC_PROVIDER_SKINNY_137,
+      chainId: 137,
+      address: getContractAddress({
+        chainId: 137,
+        type: "Skinny Optimistic Oracle",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_SKINNY_288) {
+    providers.push({
+      source: "provider",
+      type: "Skinny Optimistic Oracle",
+      url: env.NEXT_PUBLIC_PROVIDER_SKINNY_288,
+      chainId: 288,
+      address: getContractAddress({
+        chainId: 288,
+        type: "Skinny Optimistic Oracle",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_SKINNY_42161) {
+    providers.push({
+      source: "provider",
+      type: "Skinny Optimistic Oracle",
+      url: env.NEXT_PUBLIC_PROVIDER_SKINNY_42161,
+      chainId: 42161,
+      address: getContractAddress({
+        chainId: 42161,
+        type: "Skinny Optimistic Oracle",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_SKINNY_5) {
+    providers.push({
+      source: "provider",
+      type: "Skinny Optimistic Oracle",
+      url: env.NEXT_PUBLIC_PROVIDER_SKINNY_5,
+      chainId: 5,
+      address: getContractAddress({
+        chainId: 5,
+        type: "Skinny Optimistic Oracle",
+      }),
+    });
+  }
+  if (env.NEXT_PUBLIC_PROVIDER_SKINNY_10) {
+    providers.push({
+      source: "provider",
+      type: "Skinny Optimistic Oracle",
+      url: env.NEXT_PUBLIC_PROVIDER_SKINNY_10,
+      chainId: 10,
+      address: getContractAddress({
+        chainId: 10,
+        type: "Skinny Optimistic Oracle",
       }),
     });
   }

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -13,6 +13,7 @@ import {
   oracle1Ethers,
   oracle2Ethers,
   oracle3Ethers,
+  skinny1Ethers,
 } from "@libs/oracle-sdk-v2/services";
 import type { Api } from "@libs/oracle-sdk-v2/services/oraclev1/ethers";
 import type { ServiceFactories, ServiceFactory } from "@libs/oracle-sdk-v2";
@@ -38,7 +39,6 @@ type EthersServicesList = [
 ];
 const ethersServicesListInit: EthersServicesList = [[], {}];
 const [oracleEthersServices, oracleEthersApis] = config.providers
-  // TODO: this needs to be updated with oracle v2, v3, skinny based on config
   .map((config): [ProviderConfig, ServiceFactory, Api] => {
     if (config.type === "Optimistic Oracle V1")
       return [config, ...oracle1Ethers.Factory(config)];
@@ -46,9 +46,8 @@ const [oracleEthersServices, oracleEthersApis] = config.providers
       return [config, ...oracle2Ethers.Factory(config)];
     if (config.type === "Optimistic Oracle V3")
       return [config, ...oracle3Ethers.Factory(config)];
-    throw new Error(
-      `App configured with unsupported oracle type: ${config.type}`
-    );
+    // skinny optimistic oracle is left
+    return [config, ...skinny1Ethers.Factory(config)];
   })
   .reduce(
     (


### PR DESCRIPTION
## motivation
we want to be able to handle skinny oo updates when user submits transactions

## changes
this basically enables skinny oo ethers service configuration, copies most of the oo v1 ethers service in, and updates it to work with skinny oo calls. this is untested since we have no goerli subgraph for skinny oo, but it shouldnt break anything