### PR TITLE
fix: fix time formatting

### DIFF
--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -713,7 +713,7 @@ export function requestToOracleQuery(request: Request): OracleQueryUI {
       proposalExpirationTimestamp
     );
     result.formattedLivenessEndsIn = toTimeFormatted(
-      result.livenessEndsMilliseconds
+      proposalExpirationTimestamp
     );
   }
 
@@ -868,9 +868,7 @@ export function assertionToOracleQuery(assertion: Assertion): OracleQueryUI {
   }
   if (exists(expirationTime)) {
     result.livenessEndsMilliseconds = getLivenessEnds(expirationTime);
-    result.formattedLivenessEndsIn = toTimeFormatted(
-      result.livenessEndsMilliseconds
-    );
+    result.formattedLivenessEndsIn = toTimeFormatted(expirationTime);
   }
   if (exists(settlementResolution)) {
     result.valueText = settlementResolution.toString();


### PR DESCRIPTION
## motivation
some dates are being reported incorrectly

## changes
looks like we were passing time in ms to a function that expected time in seconds, changed this to pass the correct time