### PR TITLE
fix: close panel on link clicked

### DIFF
--- a/src/components/Header/MobileMenu.tsx
+++ b/src/components/Header/MobileMenu.tsx
@@ -43,6 +43,7 @@ export function MobileMenu({ panelOpen, closePanel }: Props) {
           {navLinks.map(({ label, href }) => (
             <NavItem key={href}>
               <Link
+                onClick={closePanel}
                 href={href}
                 target={isExternalLink(href) ? "_blank" : undefined}
                 style={


### PR DESCRIPTION
When the user clicks one of the links in the mobile menu panel, close the panel.