### PR TITLE
feat: toggle show / hide of bytes field

### DIFF
--- a/public/assets/icons/chevron.svg
+++ b/public/assets/icons/chevron.svg
@@ -1,3 +1,3 @@
 <svg width="8" height="5" viewBox="0 0 8 5" xmlns="http://www.w3.org/2000/svg">
-<path d="M1 1L4 4L7 1" stroke="white"/>
+<path d="M1 1L4 4L7 1" stroke="white" fill="none" />
 </svg>

--- a/src/components/Panel/AdditionalTextData.tsx
+++ b/src/components/Panel/AdditionalTextData.tsx
@@ -1,0 +1,86 @@
+import { smallMobileAndUnder } from "@/constants";
+import type { OracleQueryUI } from "@/types";
+import Chevron from "public/assets/icons/chevron.svg";
+import { useState } from "react";
+import type { CSSProperties } from "styled-components";
+import styled from "styled-components";
+
+export function AdditionalTextData({
+  description,
+  queryText,
+  queryTextHex,
+}: OracleQueryUI) {
+  const [showBytes, setShowBytes] = useState(false);
+  const hasDescription = description !== "" && description !== "0x";
+  const hasQueryText = queryText !== "" && queryText !== "0x";
+  const hasQueryTextHex = queryTextHex !== "" && queryTextHex !== "0x";
+  const chevronRotation = showBytes ? 0 : 180;
+
+  function toggleShowBytes() {
+    setShowBytes((prev) => !prev);
+  }
+
+  return (
+    <>
+      {hasDescription && (
+        <>
+          <SectionSubTitle>Description</SectionSubTitle>
+          <Text>{description}</Text>
+        </>
+      )}
+      {hasQueryText && (
+        <>
+          <SectionSubTitle>String</SectionSubTitle>
+          <Text>{queryText}</Text>
+        </>
+      )}
+      {hasQueryTextHex && (
+        <>
+          <SectionSubTitle>
+            <ToggleShowBytesButton onClick={toggleShowBytes}>
+              Bytes{" "}
+              <ChevronIcon
+                style={
+                  {
+                    "--rotation": `${chevronRotation}deg`,
+                  } as CSSProperties
+                }
+              />
+            </ToggleShowBytesButton>
+          </SectionSubTitle>
+          {showBytes && <Text>{queryTextHex}</Text>}
+        </>
+      )}
+    </>
+  );
+}
+
+const SectionSubTitle = styled.h3`
+  font: var(--body-sm);
+  font-weight: 600;
+
+  margin-top: 16px;
+`;
+
+const Text = styled.p`
+  font: var(--body-sm);
+  @media ${smallMobileAndUnder} {
+    font: var(--body-xs);
+  }
+`;
+
+const ChevronIcon = styled(Chevron)`
+  width: 12px;
+  margin-left: 8px;
+  transform: rotate(var(--rotation));
+  transition: transform var(--animation-duration);
+  path {
+    stroke: var(--dark-text);
+  }
+`;
+
+const ToggleShowBytesButton = styled.button`
+  display: flex;
+  align-items: center;
+  background: none;
+`;

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -37,6 +37,7 @@ import type { CSSProperties, ReactNode } from "react";
 import { Fragment, useEffect, useState } from "react";
 import styled from "styled-components";
 import { useAccount, useNetwork } from "wagmi";
+import { AdditionalTextData } from "./AdditionalTextData";
 import { ChainIcon } from "./ChainIcon";
 import { ExpiryTypeIcon } from "./ExpiryTypeIcon";
 import { OoTypeIcon } from "./OoTypeIcon";
@@ -58,11 +59,8 @@ export function Panel() {
     chainId,
     oracleType,
     title,
-    description,
     project,
     valueText,
-    queryText,
-    queryTextHex,
     timeUNIX,
     timeUTC,
     tokenAddress,
@@ -354,16 +352,7 @@ export function Panel() {
             <AncillaryDataIcon />
             <SectionTitle>Additional Text Data</SectionTitle>
           </SectionTitleWrapper>
-          <SectionSubTitle>Description</SectionSubTitle>
-          <DetailText>{description}</DetailText>
-          {queryText !== "" && (
-            <>
-              <SectionSubTitle>String</SectionSubTitle>
-              <DetailText>{queryText}</DetailText>
-            </>
-          )}
-          <SectionSubTitle>Bytes</SectionSubTitle>
-          <DetailText>{queryTextHex}</DetailText>
+          {content && <AdditionalTextData {...content} />}
         </DetailWrapper>
         <DetailWrapper>
           <SectionTitleWrapper>
@@ -538,8 +527,6 @@ const ActionText = styled(Text)`
   display: flex;
   align-items: center;
 `;
-
-const DetailText = styled(Text)``;
 
 const Time = styled(Text)``;
 


### PR DESCRIPTION
add additional text data component
allow toggle show / hide of additional text data bytes
hide bytes by default

<img width="121" alt="Screenshot 2023-04-12 at 14 21 24" src="https://user-images.githubusercontent.com/39741965/231455469-d0fb4f0a-a8fb-4059-9a8a-a811972673c7.png">

**[Story](https://www.chromatic.com/component?appId=63d101d13121a53332f6218c&csfId=stories-panel&buildNumber=62&k=64369dcff904555e8ae568af-320-interactive-true&h=38&b=-1)**