### PR TITLE
fix: double gas limit for approvals

### DIFF
--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -247,7 +247,16 @@ export function useProposeAction({
     error: proposePriceError,
     isLoading: isProposePriceLoading,
     reset: resetContractWrite,
-  } = useContractWrite(proposePriceConfig);
+  } = useContractWrite({
+    ...proposePriceConfig,
+    request: {
+      ...proposePriceConfig.request,
+      // increase gas limit, this is due to user potentially editing approval amount in wallet, and running out of gas
+      // we cannot unset this because typescript expects a bignumber
+      gasLimit: proposePriceConfig?.request?.gasLimit?.mul(2),
+    },
+  });
+
   const { isLoading: isProposingPrice, isSuccess } = useWaitForTransaction({
     hash: proposePriceTransaction?.hash,
   });


### PR DESCRIPTION
## motivation
approvals break when user manually edits in metmask

## changes
this is due to gas limits changing when user changes approval amounts, causing out of gas issue, we double the calculated gas limit to prevent this. a better option would be to unset the limit, but types do not allow this, so a bignumber must be supplied.