### PR TITLE
fix: add overflow-wrap to truncated titles

### DIFF
--- a/src/components/TruncatedTitle.tsx
+++ b/src/components/TruncatedTitle.tsx
@@ -22,7 +22,7 @@ export function TruncatedTitle({ title }: Props) {
 }
 
 const TitleWrapper = styled.span`
-  word-break: break-all;
+  overflow-wrap: anywhere;
 `;
 
 const TruncatedTitleWrapper = styled(TitleWrapper)`

--- a/src/components/TruncatedTitle.tsx
+++ b/src/components/TruncatedTitle.tsx
@@ -18,9 +18,13 @@ export function TruncatedTitle({ title }: Props) {
       </Tooltip>
     );
 
-  return <span>{title}</span>;
+  return <TitleWrapper>{title}</TitleWrapper>;
 }
 
-const TruncatedTitleWrapper = styled.span`
+const TitleWrapper = styled.span`
+  word-break: break-all;
+`;
+
+const TruncatedTitleWrapper = styled(TitleWrapper)`
   cursor: pointer;
 `;


### PR DESCRIPTION
Even though we are enforcing a max length on titles, this can still break when the title contains long unbroken strings like addresses. By adding [`overflow-wrap: anywhere`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) we are able to "prevent overflow, an otherwise unbreakable string of characters — like a long word or URL — may be broken at any point if there are no otherwise-acceptable break points in the line".

<img width="399" alt="Screenshot 2023-04-18 at 08 37 11" src="https://user-images.githubusercontent.com/39741965/232691868-8862140b-9eab-4aed-a897-acb4500ee5c7.png">
