### PR TITLE
fix: search missing on mobile

### DIFF
--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -56,6 +56,7 @@ export function Filters() {
             onCheckedChange={onCheckedChange}
             reset={reset}
           />
+          <Search searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
         </MobileWrapper>
       </InnerWrapper>
     </OuterWrapper>
@@ -75,7 +76,7 @@ const DesktopWrapper = styled.div`
 
 const MobileWrapper = styled.div`
   --display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: auto 1fr;
   gap: 24px;
   ${showOnMobileAndUnder}
 `;


### PR DESCRIPTION
The search bar component is not present in the filters mobile wrapper, which means the search bar does not show on mobile.

* Add the search bar component to the mobile wrapper

<img width="478" alt="Screenshot 2023-04-19 at 09 49 39" src="https://user-images.githubusercontent.com/39741965/233006039-086be607-00eb-4af0-80a0-ce11b2ccad68.png">
