### PR TITLE
fix: svg render on mobile

### DIFF
--- a/public/assets/icons/clock.svg
+++ b/public/assets/icons/clock.svg
@@ -1,11 +1,4 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_406_3757)">
 <path d="M7.99967 14.6668C11.6816 14.6668 14.6663 11.6821 14.6663 8.00016C14.6663 4.31826 11.6816 1.3335 7.99967 1.3335C4.31778 1.3335 1.33301 4.31826 1.33301 8.00016C1.33301 11.6821 4.31778 14.6668 7.99967 14.6668Z" stroke="#FF4A4A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M8 4V8L10.6667 9.33333" stroke="#FF4A4A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
-<defs>
-<clipPath id="clip0_406_3757">
-<rect width="16" height="16" fill="white"/>
-</clipPath>
-</defs>
 </svg>

--- a/public/assets/icons/info.svg
+++ b/public/assets/icons/info.svg
@@ -1,12 +1,5 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_1798_3721)">
 <path d="M8.00065 14.6663C11.6825 14.6663 14.6673 11.6816 14.6673 7.99967C14.6673 4.31778 11.6825 1.33301 8.00065 1.33301C4.31875 1.33301 1.33398 4.31778 1.33398 7.99967C1.33398 11.6816 4.31875 14.6663 8.00065 14.6663Z" stroke="#272528" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M8 10.6667V8" stroke="#272528" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M8 5.33398H8.00667" stroke="#272528" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
-<defs>
-<clipPath id="clip0_1798_3721">
-<rect width="16" height="16" fill="white"/>
-</clipPath>
-</defs>
 </svg>

--- a/src/components/GlobalStyle.tsx
+++ b/src/components/GlobalStyle.tsx
@@ -112,11 +112,6 @@ body {
   max-inline-size: 100%;
 }
 
-/* Set a size for SVG's without a width attribute */
-:where(svg):where(:not([width])) {
-  inline-size: 5rem;
-}
-
 /* Remove built-in form typography styles */
 :where(input, button, textarea, select),
 :where(input[type="file"])::-webkit-file-upload-button {

--- a/src/components/InformationIcon.tsx
+++ b/src/components/InformationIcon.tsx
@@ -20,6 +20,7 @@ export function InformationIcon({ content }: Props) {
 }
 
 const Button = styled.button`
+  background: none;
   display: inline-block;
   margin-left: 8px;
 `;


### PR DESCRIPTION
Figma adds a redundant "clip path" to svgs a lot of the time for reasons I can't quite understand. This breaks the svgs on smaller screens quite often. I've removed them from a couple here that I missed in my last pass through.