### PR TITLE
fix: flash of loader when content is loaded

### DIFF
--- a/src/components/OracleQueries.tsx
+++ b/src/components/OracleQueries.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export function OracleQueries({ page }: Props) {
   const { results: queries } = useFilterAndSearchContext();
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
   const hasQueryUrl = Object.keys(router.query).length > 0;
   const findQueryIndex = hasQueryUrl
@@ -22,7 +22,9 @@ export function OracleQueries({ page }: Props) {
     : undefined;
 
   useEffect(() => {
-    if (queries.length > 0) {
+    if (queries.length === 0) {
+      setIsLoading(true);
+    } else {
       setIsLoading(false);
     }
   }, [queries]);

--- a/src/components/OracleQueries.tsx
+++ b/src/components/OracleQueries.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export function OracleQueries({ page }: Props) {
   const { results: queries } = useFilterAndSearchContext();
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(() => queries.length === 0);
   const router = useRouter();
   const hasQueryUrl = Object.keys(router.query).length > 0;
   const findQueryIndex = hasQueryUrl
@@ -22,9 +22,7 @@ export function OracleQueries({ page }: Props) {
     : undefined;
 
   useEffect(() => {
-    if (queries.length === 0) {
-      setIsLoading(true);
-    } else {
+    if (queries.length > 0) {
       setIsLoading(false);
     }
   }, [queries]);


### PR DESCRIPTION
Use a function initializer for the is loading state, which is persisted between renders, to avoid re-rendering with the loading state as `true` on first render.