### PR TITLE
feat: parse results for projects

### DIFF
--- a/src/components/CheckboxDropdown.tsx
+++ b/src/components/CheckboxDropdown.tsx
@@ -36,9 +36,9 @@ interface Props {
 export function CheckboxDropdown({ title, items, onCheckedChange }: Props) {
   return (
     <DropdownRoot modal={false}>
-      <DropdownTrigger>
+      <_Trigger>
         {title} <DropdownChevronIcon />
-      </DropdownTrigger>
+      </_Trigger>
       <DropdownPortal>
         <DropdownContent align="start" side="bottom" sideOffset={4}>
           {Object.entries(items).map(([itemName, { count, checked }]) => (
@@ -70,4 +70,8 @@ export function CheckboxDropdown({ title, items, onCheckedChange }: Props) {
 
 const _CheckboxItem = styled(CheckboxItem)`
   ${checkboxItem}
+`;
+
+const _Trigger = styled(DropdownTrigger)`
+  border-radius: 24px;
 `;

--- a/src/components/CheckboxDropdown.tsx
+++ b/src/components/CheckboxDropdown.tsx
@@ -40,7 +40,7 @@ export function CheckboxDropdown({ title, items, onCheckedChange }: Props) {
         {title} <DropdownChevronIcon />
       </DropdownTrigger>
       <DropdownPortal>
-        <DropdownContent>
+        <DropdownContent align="start" side="bottom" sideOffset={4}>
           {Object.entries(items).map(([itemName, { count, checked }]) => (
             <_CheckboxItem
               key={itemName}

--- a/src/components/DecimalInput.tsx
+++ b/src/components/DecimalInput.tsx
@@ -1,5 +1,4 @@
 import { useHandleDecimalInput } from "@/hooks";
-import Close from "public/assets/icons/close.svg";
 import styled from "styled-components";
 
 interface Props {
@@ -17,7 +16,6 @@ interface Props {
  * A component for entering decimal values.
  * @param value The current value of the input.
  * @param onInput A callback to be called when the input value changes.
- * @param onClear A callback to be called when the input value is cleared.
  * @param addErrorMessage A callback to be called when an error message should be displayed.
  * @param removeErrorMessage A callback to be called when an error message should be removed.
  * @param disabled Whether the input should be disabled.
@@ -28,7 +26,6 @@ interface Props {
 export function DecimalInput({
   value,
   onInput,
-  onClear,
   addErrorMessage,
   removeErrorMessage,
   disabled,
@@ -63,21 +60,11 @@ export function DecimalInput({
         maxLength={79}
         spellCheck="false"
       />
-      {!!onClear && (
-        <ClearInputButton
-          aria-label="exit custom input"
-          onClick={onClear}
-          disabled={disabled}
-        >
-          <CloseIcon />
-        </ClearInputButton>
-      )}
     </Wrapper>
   );
 }
 
 const Wrapper = styled.div`
-  position: relative;
   font: var(--body-md);
   max-width: var(--panel-content-width);
   &[aria-disabled="true"] {
@@ -105,29 +92,5 @@ const Input = styled.input`
   ::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
-  }
-`;
-
-const ClearInputButton = styled.button`
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  display: grid;
-  place-items: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: var(--grey-100);
-  transition: opacity 0.2s;
-
-  &:hover {
-    opacity: 0.75;
-  }
-`;
-
-const CloseIcon = styled(Close)`
-  width: 10px;
-  path {
-    fill: var(--dark-text);
   }
 `;

--- a/src/components/DecimalInput.tsx
+++ b/src/components/DecimalInput.tsx
@@ -1,9 +1,11 @@
 import { useHandleDecimalInput } from "@/hooks";
+import Close from "public/assets/icons/close.svg";
 import styled from "styled-components";
 
 interface Props {
   value: string;
   onInput: (value: string) => void;
+  onClear?: () => void;
   addErrorMessage: (message: string) => void;
   removeErrorMessage: () => void;
   disabled?: boolean;
@@ -15,6 +17,7 @@ interface Props {
  * A component for entering decimal values.
  * @param value The current value of the input.
  * @param onInput A callback to be called when the input value changes.
+ * @param onClear A callback to be called when the input value is cleared.
  * @param addErrorMessage A callback to be called when an error message should be displayed.
  * @param removeErrorMessage A callback to be called when an error message should be removed.
  * @param disabled Whether the input should be disabled.
@@ -25,6 +28,7 @@ interface Props {
 export function DecimalInput({
   value,
   onInput,
+  onClear,
   addErrorMessage,
   removeErrorMessage,
   disabled,
@@ -59,11 +63,21 @@ export function DecimalInput({
         maxLength={79}
         spellCheck="false"
       />
+      {!!onClear && (
+        <ClearInputButton
+          aria-label="exit custom input"
+          onClick={onClear}
+          disabled={disabled}
+        >
+          <CloseIcon />
+        </ClearInputButton>
+      )}
     </Wrapper>
   );
 }
 
 const Wrapper = styled.div`
+  position: relative;
   font: var(--body-md);
   max-width: var(--panel-content-width);
   &[aria-disabled="true"] {
@@ -91,5 +105,29 @@ const Input = styled.input`
   ::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
+  }
+`;
+
+const ClearInputButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--grey-100);
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.75;
+  }
+`;
+
+const CloseIcon = styled(Close)`
+  width: 10px;
+  path {
+    fill: var(--dark-text);
   }
 `;

--- a/src/components/OracleQueryList/ItemDetails.tsx
+++ b/src/components/OracleQueryList/ItemDetails.tsx
@@ -1,3 +1,4 @@
+import { maybeGetValueTextFromOptions } from "@/helpers";
 import type { OracleQueryUI } from "@/types";
 import type { PageName } from "@shared/types";
 import { Currency } from "../Currency";
@@ -23,8 +24,10 @@ export function ItemDetails({
     bond,
     reward,
     valueText,
+    proposeOptions,
   } = item;
 
+  const valueToShow = maybeGetValueTextFromOptions(valueText, proposeOptions);
   const hasBond = bond !== null;
   const hasReward = reward !== null;
 
@@ -40,7 +43,7 @@ export function ItemDetails({
       )}
       <ItemDetailsInnerWrapper>
         <ItemDetailsText>Proposal</ItemDetailsText>
-        <ItemDetailsText>{valueText}</ItemDetailsText>
+        <ItemDetailsText>{valueToShow}</ItemDetailsText>
       </ItemDetailsInnerWrapper>
       {livenessEndsMilliseconds !== undefined &&
       timeMilliseconds !== undefined ? (
@@ -87,7 +90,7 @@ export function ItemDetails({
     <ItemDetailsWrapper>
       <ItemDetailsInnerWrapper>
         <ItemDetailsText>Settled As</ItemDetailsText>
-        <ItemDetailsText>{valueText}</ItemDetailsText>
+        <ItemDetailsText>{valueToShow}</ItemDetailsText>
       </ItemDetailsInnerWrapper>
     </ItemDetailsWrapper>
   );

--- a/src/components/OracleQueryTable/SettledCells.tsx
+++ b/src/components/OracleQueryTable/SettledCells.tsx
@@ -1,14 +1,21 @@
+import { maybeGetValueTextFromOptions } from "@/helpers";
 import type { OracleQueryUI } from "@/types";
 import { TD, Text } from "./style";
 
-export function SettledCells({ oracleType, valueText }: OracleQueryUI) {
+export function SettledCells({
+  oracleType,
+  valueText,
+  proposeOptions,
+}: OracleQueryUI) {
+  const valueToShow = maybeGetValueTextFromOptions(valueText, proposeOptions);
+
   return (
     <>
       <TD>
         <Text>{oracleType}</Text>
       </TD>
       <TD>
-        <Text>{valueText}</Text>
+        <Text>{valueToShow}</Text>
       </TD>
     </>
   );

--- a/src/components/OracleQueryTable/VerifyCells.tsx
+++ b/src/components/OracleQueryTable/VerifyCells.tsx
@@ -1,3 +1,4 @@
+import { maybeGetValueTextFromOptions } from "@/helpers";
 import type { OracleQueryUI } from "@/types";
 import { Currency } from "../Currency";
 import { LivenessProgressBar } from "../LivenessProgressBar";
@@ -5,6 +6,7 @@ import { TD, Text } from "./style";
 
 export function VerifyCells({
   valueText,
+  proposeOptions,
   timeMilliseconds,
   livenessEndsMilliseconds,
   disputeHash,
@@ -12,10 +14,11 @@ export function VerifyCells({
   chainId,
   tokenAddress,
 }: OracleQueryUI) {
+  const valueToShow = maybeGetValueTextFromOptions(valueText, proposeOptions);
   return (
     <>
       <TD>
-        <Text>{valueText}</Text>
+        <Text>{valueToShow}</Text>
       </TD>
       <TD>
         <Text>

--- a/src/components/Panel/Actions/Actions.tsx
+++ b/src/components/Panel/Actions/Actions.tsx
@@ -1,11 +1,14 @@
-import { ConnectButton, DecimalInput } from "@/components";
+import { ConnectButton } from "@/components";
 import { connectWallet, settled, smallMobileAndUnder } from "@/constants";
-import { usePageContext, usePrimaryPanelAction } from "@/hooks";
+import {
+  usePageContext,
+  usePrimaryPanelAction,
+  useProposePriceInput,
+} from "@/hooks";
 import type { OracleQueryUI } from "@/types";
 import Pencil from "public/assets/icons/pencil.svg";
 import Settled from "public/assets/icons/settled.svg";
 import type { CSSProperties } from "react";
-import { useState } from "react";
 import styled from "styled-components";
 import { useAccount, useNetwork } from "wagmi";
 import { SectionTitle, SectionTitleWrapper, Text } from "../style";
@@ -13,15 +16,15 @@ import { Details } from "./Details";
 import { Errors } from "./Errors";
 import { Message } from "./Message";
 import { PrimaryActionButton } from "./PrimaryActionButton";
+import { ProposeInput } from "./ProposeInput";
 
 interface Props {
   query: OracleQueryUI;
 }
 export function Actions({ query }: Props) {
-  const [proposePriceInput, setProposePriceInput] = useState("");
-  const [inputError, setInputError] = useState("");
   const { chainId, oracleType, valueText, actionType } = query;
-
+  const { proposePriceInput, setProposePriceInput, inputError, setInputError } =
+    useProposePriceInput();
   const primaryAction = usePrimaryPanelAction({
     query,
     proposePriceInput,
@@ -80,15 +83,13 @@ export function Actions({ query }: Props) {
         <SectionTitle>{actionsTitle}</SectionTitle>
       </SectionTitleWrapper>
       {pageIsPropose ? (
-        <InputWrapper>
-          <DecimalInput
-            value={proposePriceInput}
-            onInput={setProposePriceInput}
-            addErrorMessage={setInputError}
-            disabled={disableInput}
-            removeErrorMessage={() => setInputError("")}
-          />
-        </InputWrapper>
+        <ProposeInput
+          value={proposePriceInput}
+          onInput={setProposePriceInput}
+          addErrorMessage={setInputError}
+          removeErrorMessage={() => setInputError("")}
+          disabled={disableInput}
+        />
       ) : (
         <ValueWrapper
           style={
@@ -131,11 +132,6 @@ const ValueWrapper = styled.div`
   padding-inline: 16px;
   border-radius: 4px;
   background: var(--white);
-`;
-
-const InputWrapper = styled.div`
-  margin-top: 16px;
-  margin-bottom: 20px;
 `;
 
 const ValueText = styled(Text)`

--- a/src/components/Panel/Actions/Actions.tsx
+++ b/src/components/Panel/Actions/Actions.tsx
@@ -23,8 +23,8 @@ interface Props {
 }
 export function Actions({ query }: Props) {
   const { chainId, oracleType, valueText, actionType } = query;
-  const { proposePriceInput, setProposePriceInput, inputError, setInputError } =
-    useProposePriceInput();
+  const { proposePriceInput, inputError, ...inputProps } =
+    useProposePriceInput(query);
   const primaryAction = usePrimaryPanelAction({
     query,
     proposePriceInput,
@@ -55,7 +55,11 @@ export function Actions({ query }: Props) {
   const showConnectButton =
     isConnectWallet && !pageIsSettled && !alreadyProposed && !alreadySettled;
   const disableInput =
-    !address || isWrongChain || alreadyProposed || alreadySettled;
+    !address ||
+    isWrongChain ||
+    alreadyProposed ||
+    alreadySettled ||
+    primaryAction?.disabled === true;
 
   const errors = [inputError, ...(primaryAction?.errors || [])].filter(Boolean);
   const actionsTitle = getActionsTitle();
@@ -85,10 +89,8 @@ export function Actions({ query }: Props) {
       {pageIsPropose ? (
         <ProposeInput
           value={proposePriceInput}
-          onInput={setProposePriceInput}
-          addErrorMessage={setInputError}
-          removeErrorMessage={() => setInputError("")}
           disabled={disableInput}
+          {...inputProps}
         />
       ) : (
         <ValueWrapper

--- a/src/components/Panel/Actions/Actions.tsx
+++ b/src/components/Panel/Actions/Actions.tsx
@@ -1,5 +1,6 @@
 import { ConnectButton } from "@/components";
 import { connectWallet, settled, smallMobileAndUnder } from "@/constants";
+import { maybeGetValueTextFromOptions } from "@/helpers";
 import {
   usePageContext,
   usePrimaryPanelAction,
@@ -22,7 +23,7 @@ interface Props {
   query: OracleQueryUI;
 }
 export function Actions({ query }: Props) {
-  const { chainId, oracleType, valueText, actionType } = query;
+  const { chainId, oracleType, valueText, actionType, proposeOptions } = query;
   const { proposePriceInput, inputError, ...inputProps } =
     useProposePriceInput(query);
   const primaryAction = usePrimaryPanelAction({
@@ -59,6 +60,7 @@ export function Actions({ query }: Props) {
   const errors = [inputError, ...(primaryAction?.errors || [])].filter(Boolean);
   const actionsTitle = getActionsTitle();
   const actionsIcon = pageIsSettled ? <SettledIcon /> : <PencilIcon />;
+  const valueToShow = maybeGetValueTextFromOptions(valueText, proposeOptions);
 
   function getActionsTitle() {
     if (pageIsSettled) return "Settled as";
@@ -95,7 +97,7 @@ export function Actions({ query }: Props) {
             } as CSSProperties
           }
         >
-          <ValueText>{valueText}</ValueText>
+          <ValueText>{valueToShow}</ValueText>
         </ValueWrapper>
       )}
       {!pageIsSettled && <Details {...query} />}

--- a/src/components/Panel/Actions/Actions.tsx
+++ b/src/components/Panel/Actions/Actions.tsx
@@ -55,12 +55,7 @@ export function Actions({ query }: Props) {
   const showConnectButton =
     isConnectWallet && !pageIsSettled && !alreadyProposed && !alreadySettled;
   const disableInput =
-    !address ||
-    isWrongChain ||
-    alreadyProposed ||
-    alreadySettled ||
-    primaryAction?.disabled === true;
-
+    !address || isWrongChain || alreadyProposed || alreadySettled;
   const errors = [inputError, ...(primaryAction?.errors || [])].filter(Boolean);
   const actionsTitle = getActionsTitle();
   const actionsIcon = pageIsSettled ? <SettledIcon /> : <PencilIcon />;

--- a/src/components/Panel/Actions/ProposeInput.tsx
+++ b/src/components/Panel/Actions/ProposeInput.tsx
@@ -1,17 +1,24 @@
-import { DecimalInput } from "@/components/DecimalInput";
+import { DecimalInput, RadioDropdown } from "@/components";
+import type { DropdownItem } from "@/types";
 import styled from "styled-components";
 
 interface Props {
   value: string;
+  disabled: boolean;
+  items: DropdownItem[] | undefined;
+  selected: DropdownItem | undefined;
+  isCustomInput: boolean;
   onInput: (value: string) => void;
+  onSelect: (item: DropdownItem) => void;
   addErrorMessage: (value: string) => void;
   removeErrorMessage: () => void;
-  disabled: boolean;
 }
-export function ProposeInput(delegatedProps: Props) {
+export function ProposeInput({ isCustomInput, ...props }: Props) {
+  const isDropdown = !isCustomInput && !!props.items && props.items.length > 0;
+
   return (
     <Wrapper>
-      <DecimalInput {...delegatedProps} />
+      {isDropdown ? <RadioDropdown {...props} /> : <DecimalInput {...props} />}
     </Wrapper>
   );
 }

--- a/src/components/Panel/Actions/ProposeInput.tsx
+++ b/src/components/Panel/Actions/ProposeInput.tsx
@@ -1,5 +1,6 @@
 import { DecimalInput, RadioDropdown } from "@/components";
 import type { DropdownItem } from "@/types";
+import Close from "public/assets/icons/close.svg";
 import styled from "styled-components";
 
 interface Props {
@@ -12,18 +13,57 @@ interface Props {
   onSelect: (item: DropdownItem) => void;
   addErrorMessage: (value: string) => void;
   removeErrorMessage: () => void;
+  exitCustomInput: () => void;
 }
-export function ProposeInput({ isCustomInput, ...props }: Props) {
+export function ProposeInput({
+  isCustomInput,
+  exitCustomInput,
+  ...props
+}: Props) {
   const isDropdown = !isCustomInput && !!props.items && props.items.length > 0;
 
   return (
     <Wrapper>
       {isDropdown ? <RadioDropdown {...props} /> : <DecimalInput {...props} />}
+      {isCustomInput && (
+        <ClearInputButton
+          aria-label="exit custom input"
+          onClick={exitCustomInput}
+          disabled={props.disabled}
+        >
+          <CloseIcon />
+        </ClearInputButton>
+      )}
     </Wrapper>
   );
 }
 
 const Wrapper = styled.div`
+  position: relative;
   margin-top: 16px;
   margin-bottom: 20px;
+`;
+
+const ClearInputButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--grey-100);
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.75;
+  }
+`;
+
+const CloseIcon = styled(Close)`
+  width: 10px;
+  path {
+    fill: var(--dark-text);
+  }
 `;

--- a/src/components/Panel/Actions/ProposeInput.tsx
+++ b/src/components/Panel/Actions/ProposeInput.tsx
@@ -1,0 +1,22 @@
+import { DecimalInput } from "@/components/DecimalInput";
+import styled from "styled-components";
+
+interface Props {
+  value: string;
+  onInput: (value: string) => void;
+  addErrorMessage: (value: string) => void;
+  removeErrorMessage: () => void;
+  disabled: boolean;
+}
+export function ProposeInput(delegatedProps: Props) {
+  return (
+    <Wrapper>
+      <DecimalInput {...delegatedProps} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  margin-top: 16px;
+  margin-bottom: 20px;
+`;

--- a/src/components/RadioDropdown.tsx
+++ b/src/components/RadioDropdown.tsx
@@ -13,6 +13,7 @@ interface Props {
   items: DropdownItem[] | undefined;
   selected: DropdownItem | undefined;
   onSelect: ((item: DropdownItem) => void) | undefined;
+  disabled?: boolean;
 }
 /**
  * Dropdown menu with radio items
@@ -20,12 +21,12 @@ interface Props {
  * @param selected - the selected item
  * @param onSelect - the callback to call when an item is selected
  */
-export function RadioDropdown({ items, selected, onSelect }: Props) {
+export function RadioDropdown({ items, selected, onSelect, disabled }: Props) {
   if (!items || !onSelect) return null;
 
   return (
     <DropdownRoot modal={false}>
-      <_Trigger>
+      <_Trigger disabled={disabled}>
         {selected?.label ?? "Select option"} <DropdownChevronIcon />
       </_Trigger>
       <DropdownPortal>

--- a/src/components/RadioDropdown.tsx
+++ b/src/components/RadioDropdown.tsx
@@ -5,18 +5,14 @@ import {
   DropdownRoot,
   DropdownTrigger,
 } from "@/components/style";
+import type { DropdownItem } from "@/types";
 import { RadioItem } from "@radix-ui/react-dropdown-menu";
 import styled from "styled-components";
 
-type Item = {
-  label: string;
-  value: string | number;
-};
-
 interface Props {
-  items: Item[];
-  selected: Item;
-  onSelect: (item: Item) => void;
+  items: DropdownItem[] | undefined;
+  selected: DropdownItem | undefined;
+  onSelect: ((item: DropdownItem) => void) | undefined;
 }
 /**
  * Dropdown menu with radio items
@@ -25,13 +21,15 @@ interface Props {
  * @param onSelect - the callback to call when an item is selected
  */
 export function RadioDropdown({ items, selected, onSelect }: Props) {
+  if (!items || !onSelect) return null;
+
   return (
     <DropdownRoot modal={false}>
       <_Trigger>
-        {selected.label} <DropdownChevronIcon />
+        {selected?.label ?? "Select option"} <DropdownChevronIcon />
       </_Trigger>
       <DropdownPortal>
-        <_Content>
+        <_Content align="start" side="bottom" sideOffset={4}>
           {items.map((item) => (
             <_RadioItem
               key={item.value}
@@ -50,21 +48,17 @@ export function RadioDropdown({ items, selected, onSelect }: Props) {
 const _Trigger = styled(DropdownTrigger)`
   min-height: 40px;
   border-radius: 4px;
-  min-width: 128px;
-  width: fit-content;
   gap: 12px;
 `;
 
 const _Content = styled(DropdownContent)`
-  min-width: 128px;
-  width: fit-content;
   padding-block: 0;
+  z-index: 2;
 `;
 
 const _RadioItem = styled(RadioItem)`
   display: flex;
   align-items: center;
-  width: 100%;
   min-height: 40px;
   padding-left: 18px;
   padding-right: 18px;

--- a/src/components/RadioDropdown.tsx
+++ b/src/components/RadioDropdown.tsx
@@ -38,6 +38,9 @@ export function RadioDropdown({ items, selected, onSelect, disabled }: Props) {
               onSelect={() => onSelect(item)}
             >
               {item.label}
+              {item.secondaryLabel && (
+                <SecondaryLabel>({item.secondaryLabel})</SecondaryLabel>
+              )}
             </_RadioItem>
           ))}
         </_Content>
@@ -60,7 +63,12 @@ const _Content = styled(DropdownContent)`
 const _RadioItem = styled(RadioItem)`
   display: flex;
   align-items: center;
+  justify-content: space-between;
   min-height: 40px;
   padding-left: 18px;
   padding-right: 18px;
+`;
+
+const SecondaryLabel = styled.span`
+  color: var(--blue-grey-300);
 `;

--- a/src/components/style.tsx
+++ b/src/components/style.tsx
@@ -28,7 +28,7 @@ export const DropdownTrigger = styled(RadixDropdown.Trigger)`
   color: var(--blue-grey-500);
   text-align: left;
   border: 1px solid var(--blue-grey-400);
-  border-radius: 24px;
+  border-radius: 4px;
   padding-left: 18px;
   padding-right: 22px;
   &[data-state="open"] {
@@ -39,8 +39,7 @@ export const DropdownTrigger = styled(RadixDropdown.Trigger)`
 `;
 
 export const DropdownContent = styled(RadixDropdown.Content)`
-  width: fit-content;
-  min-width: 220px;
+  width: var(--radix-dropdown-menu-trigger-width);
   margin-top: 4px;
   font: var(--body-sm);
   color: var(--blue-grey-500);

--- a/src/components/style.tsx
+++ b/src/components/style.tsx
@@ -36,6 +36,9 @@ export const DropdownTrigger = styled(RadixDropdown.Trigger)`
       transform: rotate(180deg);
     }
   }
+  &[data-disabled] {
+    opacity: 0.25;
+  }
 `;
 
 export const DropdownContent = styled(RadixDropdown.Content)`

--- a/src/components/style.tsx
+++ b/src/components/style.tsx
@@ -22,7 +22,7 @@ export const DropdownTrigger = styled(RadixDropdown.Trigger)`
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  min-height: 45px;
+  min-height: 44px;
   background: var(--white);
   font: var(--body-sm);
   color: var(--blue-grey-500);

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -689,11 +689,12 @@ export function requestToOracleQuery(request: Request): OracleQueryUI {
   }
 
   if (exists(identifier) && exists(result.queryText)) {
-    const { title, description, umipUrl, umipNumber, project } =
+    const { title, description, umipUrl, umipNumber, project, proposeOptions } =
       getQueryMetaData(identifier, result.queryText);
     result.title = title;
     result.description = description;
     result.project = project;
+    result.proposeOptions = proposeOptions;
     result.moreInformation = makeMoreInformationList(
       request,
       umipNumber,

--- a/src/helpers/converters.tsx
+++ b/src/helpers/converters.tsx
@@ -1,12 +1,11 @@
 import { config } from "@/constants";
-import { parseIdentifier } from "@libs/utils";
 import type {
   ActionType,
   MoreInformationItem,
   OracleQueryUI,
   SolidityRequest,
 } from "@/types";
-import { exists } from "@libs/utils";
+import { exists, parseIdentifier } from "@libs/utils";
 import { chainsById } from "@shared/constants";
 import {
   disputeAssertionAbi,
@@ -882,9 +881,23 @@ export function assertionToOracleQuery(assertion: Assertion): OracleQueryUI {
     result.description = result.queryText;
     if (isOptimisticGovernor(result.queryText)) {
       result.project = "OSnap";
-      const match = result.queryText.match(/explanation:"(.*?)",rules:/);
-      if (match && match[1]) {
-        result.title = `OSnap Request ${match[1]}`;
+      const explanationRegex = result.queryText.match(
+        /explanation:"(.*?)",rules:/
+      );
+      const rulesRegex = result.queryText.match(/rules:"(.*?)"/);
+      if (explanationRegex && explanationRegex[1]) {
+        result.title = `OSnap Request ${explanationRegex[1]}`;
+        if (rulesRegex && rulesRegex[1]) {
+          result.description = (
+            <>
+              OSnap Request {explanationRegex[1]}
+              <br />
+              Rules:
+              <br />
+              {rulesRegex[1]}
+            </>
+          );
+        }
       } else {
         result.title = "OSnap Request";
       }

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,6 +1,6 @@
 import { mobileAndUnder, tabletAndUnder } from "@/constants";
 import type { OracleQueryList } from "@/contexts";
-import type { OracleQueryUI } from "@/types";
+import type { DropdownItem, OracleQueryUI } from "@/types";
 import { capitalize, words } from "lodash";
 import { css } from "styled-components";
 
@@ -145,4 +145,11 @@ export function getPageForQuery({ actionType }: OracleQueryUI) {
     default:
       return "settled";
   }
+}
+
+export function maybeGetValueTextFromOptions(
+  valueText: string | null | undefined,
+  options: DropdownItem[] | undefined
+) {
+  return options?.find(({ value }) => value === valueText)?.label ?? valueText;
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,5 +5,6 @@ export * from "./filters";
 export * from "./handleQueryInUrl";
 export * from "./helpers";
 export * from "./page";
-export * from "./votingInfo";
+export * from "./proposePriceInput";
 export * from "./queries";
+export * from "./votingInfo";

--- a/src/hooks/proposePriceInput.ts
+++ b/src/hooks/proposePriceInput.ts
@@ -1,13 +1,37 @@
+import type { DropdownItem, OracleQueryUI } from "@/types";
 import { useState } from "react";
 
-export function useProposePriceInput() {
+export function useProposePriceInput(query: OracleQueryUI) {
   const [proposePriceInput, setProposePriceInput] = useState("");
+  const [isCustomInput, setIsCustomInput] = useState(false);
   const [inputError, setInputError] = useState("");
+
+  const items = [
+    { label: "Yes", value: "1" },
+    { label: "No", value: "0" },
+  ];
+
+  const selected = items.find(({ value }) => value === proposePriceInput);
+
+  function onSelect(item: DropdownItem) {
+    setProposePriceInput(item.value.toString());
+  }
+
+  function onClear() {
+    setProposePriceInput("");
+    setIsCustomInput(false);
+  }
 
   return {
     proposePriceInput,
-    setProposePriceInput,
     inputError,
-    setInputError,
+    items,
+    selected,
+    isCustomInput,
+    onSelect,
+    onClear,
+    onInput: setProposePriceInput,
+    addErrorMessage: setInputError,
+    removeErrorMessage: () => setInputError(""),
   };
 }

--- a/src/hooks/proposePriceInput.ts
+++ b/src/hooks/proposePriceInput.ts
@@ -1,23 +1,24 @@
 import type { DropdownItem, OracleQueryUI } from "@/types";
 import { useState } from "react";
 
-export function useProposePriceInput(query: OracleQueryUI) {
+export function useProposePriceInput({ proposeOptions }: OracleQueryUI) {
   const [proposePriceInput, setProposePriceInput] = useState("");
   const [isCustomInput, setIsCustomInput] = useState(false);
   const [inputError, setInputError] = useState("");
 
-  const items = [
-    { label: "Yes", value: "1", secondaryLabel: "poes" },
-    { label: "No", value: "0" },
-  ];
-
-  const selected = items.find(({ value }) => value === proposePriceInput);
+  const selected = proposeOptions?.find(
+    ({ value }) => value === proposePriceInput
+  );
 
   function onSelect(item: DropdownItem) {
-    setProposePriceInput(item.value.toString());
+    if (item.value === "custom") {
+      setIsCustomInput(true);
+    } else {
+      setProposePriceInput(item.value.toString());
+    }
   }
 
-  function onClear() {
+  function exitCustomInput() {
     setProposePriceInput("");
     setIsCustomInput(false);
   }
@@ -25,11 +26,11 @@ export function useProposePriceInput(query: OracleQueryUI) {
   return {
     proposePriceInput,
     inputError,
-    items,
+    items: proposeOptions,
     selected,
     isCustomInput,
     onSelect,
-    onClear,
+    exitCustomInput,
     onInput: setProposePriceInput,
     addErrorMessage: setInputError,
     removeErrorMessage: () => setInputError(""),

--- a/src/hooks/proposePriceInput.ts
+++ b/src/hooks/proposePriceInput.ts
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+export function useProposePriceInput() {
+  const [proposePriceInput, setProposePriceInput] = useState("");
+  const [inputError, setInputError] = useState("");
+
+  return {
+    proposePriceInput,
+    setProposePriceInput,
+    inputError,
+    setInputError,
+  };
+}

--- a/src/hooks/proposePriceInput.ts
+++ b/src/hooks/proposePriceInput.ts
@@ -7,7 +7,7 @@ export function useProposePriceInput(query: OracleQueryUI) {
   const [inputError, setInputError] = useState("");
 
   const items = [
-    { label: "Yes", value: "1" },
+    { label: "Yes", value: "1", secondaryLabel: "poes" },
     { label: "No", value: "0" },
   ];
 

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -64,6 +64,7 @@ export type OracleQueryUI = {
   oracleType: OracleType;
   oracleAddress: Address;
   project: Project;
+  proposeOptions?: DropdownItem[] | undefined;
   title?: string;
   description?: ReactNode;
   expiryType?: ExpiryType | null;
@@ -416,6 +417,7 @@ export type MetaData = {
   umipUrl: string | undefined;
   umipNumber: string | undefined;
   project: Project;
+  proposeOptions: DropdownItem[] | undefined;
 };
 
 export type DropdownItem = {

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -421,4 +421,5 @@ export type MetaData = {
 export type DropdownItem = {
   label: string;
   value: string | number;
+  secondaryLabel?: string;
 };

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -417,3 +417,8 @@ export type MetaData = {
   umipNumber: string | undefined;
   project: Project;
 };
+
+export type DropdownItem = {
+  label: string;
+  value: string | number;
+};


### PR DESCRIPTION
The projects that we specifically handle are defined as:

`export const projects = [
  "Unknown",
  "Polymarket",
  "Cozy Finance",
  "Across",
  "Sherlock",
  "OSnap",
] as const;`

Of these, Sherlock does not appear in the UI because of how their flow works (they do everything in a single transaction). 

OSnap only runs on OOv3, and therefore their assertions will never end up on the propose page and don't need to have inputs. I have however added some logic for parsing the description from the OSnap claim data.

Polymarket has logic that has been copied wholesale from the voter dapp.

Cozy Finance and Across both use a simple yes = 1 no = 0 logic and can therefore have the options:

`[
    { label: "Yes", value: "1", secondaryLabel: "1" },
    { label: "No", value: "0", secondaryLabel: "0" },
  ]`