### PR TITLE
fix: add overflow wrap to tooltips

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -73,6 +73,7 @@ const slideLeftAndFade = keyframes`
 const Content = styled(RadixTooltip.Content)`
   z-index: 2;
   max-width: 400px;
+  overflow-wrap: break-word;
   padding: 20px;
   font: var(--body-sm);
   color: var(--dark-text);


### PR DESCRIPTION
Tooltips text overflows with long words, add overflow-wrap to fix.