### PR TITLE
fix: add final fee to bond

### DIFF
--- a/src/components/OracleQueryTable/ProposeCells.tsx
+++ b/src/components/OracleQueryTable/ProposeCells.tsx
@@ -2,12 +2,12 @@ import type { OracleQueryUI } from "@/types";
 import styled from "styled-components";
 import { Currency } from "../Currency";
 import { TD, Text } from "./style";
+import { exists } from "@libs/utils";
 
 export function ProposeCells({ query }: { query: OracleQueryUI }) {
   const { oracleType, tokenAddress, chainId, bond, reward } = query;
 
-  const hasReward = reward !== null;
-
+  const hasReward = exists(reward);
   return (
     <>
       <TD>

--- a/src/helpers/converters.tsx
+++ b/src/helpers/converters.tsx
@@ -441,8 +441,9 @@ function makeSettleAssertionParams({
 
 function getOOV2SpecificValues(request: Request) {
   const isV2 = isOOV2PriceRequest(request);
-
-  const bond = isV2 && request.bond ? request.bond : request.finalFee;
+  const finalFee = request.finalFee ?? BigNumber.from(0);
+  // bond is final fee and bond together
+  const bond = isV2 && request.bond ? request.bond.add(finalFee) : finalFee;
   const customLiveness = isV2 ? request.customLiveness : null;
   const eventBased = isV2 ? request.eventBased : null;
 


### PR DESCRIPTION
## motivation
final fee was not included in bond, some people were not seeing they would be debited more than what was shown on ui

## changes
this makes sure final fee gets added to bond in all tables

before
![image](https://user-images.githubusercontent.com/4429761/233164576-3c8c2621-38b3-45c8-adc8-99b84a8caedc.png)
after
![image](https://user-images.githubusercontent.com/4429761/233164507-835d6652-86c1-4e17-a9f2-72533ee28e89.png)
