### PR TITLE
fix: keep fetching requests until we have them all

### DIFF
--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
@@ -1,9 +1,15 @@
 import { chainsById } from "@shared/constants";
-import type { ChainId, OracleType, PriceRequestsQuery } from "@shared/types";
+import type {
+  ChainId,
+  OOV1GraphEntity,
+  OOV2GraphEntity,
+  OracleType,
+  PriceRequestsQuery,
+} from "@shared/types";
 import { makeQueryName } from "@shared/utils";
 import request, { gql } from "graphql-request";
 
-export async function getPriceRequests<Query extends PriceRequestsQuery>(
+export async function getPriceRequests(
   url: string,
   chainId: ChainId,
   oracleType: OracleType
@@ -11,53 +17,87 @@ export async function getPriceRequests<Query extends PriceRequestsQuery>(
   const chainName = chainsById[chainId];
   const queryName = makeQueryName(oracleType, chainName);
   const isV2 = oracleType === "Optimistic Oracle V2";
+  const result = await fetchAllRequests(url, queryName, isV2);
+  return result;
+}
+
+async function fetchAllRequests(url: string, queryName: string, isV2: boolean) {
+  const result: (OOV1GraphEntity | OOV2GraphEntity)[] = [];
+  let skip = 0;
+  const first = 1000;
+  let requests = await fetchPriceRequests(
+    url,
+    makeQuery(queryName, isV2, first, skip)
+  );
+  while (requests.length > 0) {
+    result.push(...requests);
+    skip += first;
+    requests = await fetchPriceRequests(
+      url,
+      makeQuery(queryName, isV2, first, skip)
+    );
+  }
+  return result;
+}
+
+async function fetchPriceRequests(url: string, query: string) {
+  const result = await request<PriceRequestsQuery>(url, query);
+  return result.optimisticPriceRequests;
+}
+
+function makeQuery(
+  queryName: string,
+  isV2: boolean,
+  first: number,
+  skip: number
+) {
   const query = gql`
-    query ${queryName} {
-      optimisticPriceRequests(orderBy: time, orderDirection: desc, first:1000) {
-        id
-        identifier
-        ancillaryData
-        time
-        requester
-        currency
-        reward
-        finalFee
-        proposer
-        proposedPrice
-        proposalExpirationTimestamp
-        disputer
-        settlementPrice
-        settlementPayout
-        settlementRecipient
-        state
-        requestTimestamp
-        requestBlockNumber
-        requestHash
-        requestLogIndex
-        proposalTimestamp
-        proposalBlockNumber
-        proposalHash
-        proposalLogIndex
-        disputeTimestamp
-        disputeBlockNumber
-        disputeHash
-        disputeLogIndex
-        settlementTimestamp
-        settlementBlockNumber
-        settlementHash
-        settlementLogIndex
-        ${
-          isV2
-            ? `
-              customLiveness
-              bond
-              eventBased
-              `
-            : ""
-        }
+  query ${queryName} {
+    optimisticPriceRequests(orderBy: time, orderDirection: desc, first: ${first}, skip: ${skip}) {
+      id
+      identifier
+      ancillaryData
+      time
+      requester
+      currency
+      reward
+      finalFee
+      proposer
+      proposedPrice
+      proposalExpirationTimestamp
+      disputer
+      settlementPrice
+      settlementPayout
+      settlementRecipient
+      state
+      requestTimestamp
+      requestBlockNumber
+      requestHash
+      requestLogIndex
+      proposalTimestamp
+      proposalBlockNumber
+      proposalHash
+      proposalLogIndex
+      disputeTimestamp
+      disputeBlockNumber
+      disputeHash
+      disputeLogIndex
+      settlementTimestamp
+      settlementBlockNumber
+      settlementHash
+      settlementLogIndex
+      ${
+        isV2
+          ? `
+            customLiveness
+            bond
+            eventBased
+            `
+          : ""
       }
     }
-  `;
-  const result = await request<Query>(url, query);
-  return result.optimisticPriceRequests;
+  }
+`;
+
+  return query;
 }

--- a/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
@@ -1,45 +1,73 @@
 import { chainsById } from "@shared/constants";
-import type { ChainId, OOV3GraphQuery } from "@shared/types";
+import type { ChainId, OOV3GraphEntity, OOV3GraphQuery } from "@shared/types";
 import { makeQueryName } from "@shared/utils";
 import request, { gql } from "graphql-request";
 
 export async function getAssertions(url: string, chainId: ChainId) {
   const chainName = chainsById[chainId];
   const queryName = makeQueryName("Optimistic Oracle V3", chainName);
-  const query = gql`
-    query ${queryName} {
-      assertions {
-        id
-        assertionId
-        identifier
-        domainId
-        claim
-        asserter
-        callbackRecipient
-        escalationManager
-        caller
-        expirationTime
-        currency
-        bond
-        disputer
-        settlementPayout
-        settlementRecipient
-        settlementResolution
-        assertionTimestamp
-        assertionBlockNumber
-        assertionHash
-        assertionLogIndex
-        disputeTimestamp
-        disputeBlockNumber
-        disputeHash
-        disputeLogIndex
-        settlementTimestamp
-        settlementBlockNumber
-        settlementHash
-        settlementLogIndex
-      }
-    }
-  `;
+  const result = await fetchAllAssertions(url, queryName);
+  return result;
+}
+
+async function fetchAllAssertions(url: string, queryName: string) {
+  const result: OOV3GraphEntity[] = [];
+  let skip = 0;
+  const first = 1000;
+  let assertions = await fetchAssertions(
+    url,
+    makeQuery(queryName, first, skip)
+  );
+
+  while (assertions.length > 0) {
+    result.push(...assertions);
+    skip += first;
+    assertions = await fetchAssertions(url, makeQuery(queryName, first, skip));
+  }
+
+  return result;
+}
+
+async function fetchAssertions(url: string, query: string) {
   const result = await request<OOV3GraphQuery>(url, query);
   return result.assertions;
+}
+
+function makeQuery(queryName: string, first: number, skip: number) {
+  const query = gql`
+  query ${queryName} {
+    assertions(first: ${first}, skip: ${skip}) {
+      id
+      assertionId
+      identifier
+      domainId
+      claim
+      asserter
+      callbackRecipient
+      escalationManager
+      caller
+      expirationTime
+      currency
+      bond
+      disputer
+      settlementPayout
+      settlementRecipient
+      settlementResolution
+      assertionTimestamp
+      assertionBlockNumber
+      assertionHash
+      assertionLogIndex
+      disputeTimestamp
+      disputeBlockNumber
+      disputeHash
+      disputeLogIndex
+      settlementTimestamp
+      settlementBlockNumber
+      settlementHash
+      settlementLogIndex
+    }
+  }
+`;
+
+  return query;
 }


### PR DESCRIPTION
The graph limits how many items we can request in a query. We need to keep querying and use the `skip` parameter to get the next batch. We can't do this with pages because we need _all_ the requests for stuff like getting old requests from the URL. I considered downloading all these older requests and serving them in a file, but many of the old requests are not resolved and therefore can change.

* Add `fetchAllRequests` and `fetchAllAssertions` logic that downloads all the requests/assertions by paging the data.