### PR TITLE
fix: add ignore location to fuse config

### DIFF
--- a/src/hooks/filters.ts
+++ b/src/hooks/filters.ts
@@ -39,6 +39,7 @@ export function useSearch(queries: OracleQueryUI[]) {
     return new Fuse(queries, {
       keys,
       ignoreLocation: true,
+      threshold: 0.3,
     });
   }, [queries]);
 

--- a/src/hooks/filters.ts
+++ b/src/hooks/filters.ts
@@ -36,7 +36,10 @@ export function useSearch(queries: OracleQueryUI[]) {
   const [searchTerm, setSearchTerm] = useState("");
 
   const fuse = useMemo(() => {
-    return new Fuse(queries, { keys });
+    return new Fuse(queries, {
+      keys,
+      ignoreLocation: true,
+    });
   }, [queries]);
 
   const results = useMemo(() => {


### PR DESCRIPTION
The Fuse fuzzy search library has a default setting where it wants the search string to appear at the start of the search text. This is not what we want because we want to be able to find things anywhere in the string. By setting `ignoreLocation` to true, the search looks throughout the whole string instead.