### PR TITLE
fix: sort verify page queries by liveness ends

### DIFF
--- a/shared/utils/graphql.ts
+++ b/shared/utils/graphql.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import type {
   AssertionGraphEntity,
   ChainId,
@@ -13,12 +12,13 @@ import type {
 import { BigNumber } from "ethers";
 import type { Address } from "wagmi";
 
-export function isAddress(maybeAddress:string): maybeAddress is Address {
-  return '0x' == maybeAddress.slice(0,2)
+export function isAddress(maybeAddress: string): maybeAddress is Address {
+  return "0x" == maybeAddress.slice(0, 2);
 }
-export function assertAddress(maybeAddress:string): Address{
-  if(!isAddress(maybeAddress)) throw new Error(`${maybeAddress} is not a valid address.`)
-  return maybeAddress
+export function assertAddress(maybeAddress: string): Address {
+  if (!isAddress(maybeAddress))
+    throw new Error(`${maybeAddress} is not a valid address.`);
+  return maybeAddress;
 }
 export function handleGraphqlNullableStringOrBytes<
   EntityKey extends { [key: string]: string | null }

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -1,31 +1,31 @@
-import unionWith from "lodash/unionWith";
+import type { ProviderConfig } from "@/constants";
 import { config } from "@/constants";
 import {
   assertionToOracleQuery,
   getPageForQuery,
   requestToOracleQuery,
-  sortQueriesByDate,
+  sortQueries,
 } from "@/helpers";
 import type { OracleQueryUI } from "@/types";
+import type { ServiceFactories, ServiceFactory } from "@libs/oracle-sdk-v2";
 import { Client } from "@libs/oracle-sdk-v2";
 import {
-  oracles,
   oracle1Ethers,
   oracle2Ethers,
   oracle3Ethers,
+  oracles,
   skinny1Ethers,
 } from "@libs/oracle-sdk-v2/services";
 import type { Api } from "@libs/oracle-sdk-v2/services/oraclev1/ethers";
-import type { ServiceFactories, ServiceFactory } from "@libs/oracle-sdk-v2";
-import type { ProviderConfig } from "@/constants";
 import type {
   Assertion,
   Assertions,
-  Request,
-  Requests,
   ChainId,
   OracleType,
+  Request,
+  Requests,
 } from "@shared/types";
+import unionWith from "lodash/unionWith";
 import type { ReactNode } from "react";
 import { createContext, useEffect, useReducer, useState } from "react";
 
@@ -152,7 +152,7 @@ function DataReducerFactory<Input extends Request | Assertion>(
     return {
       ...state,
       all: { ...all },
-      ...sortQueriesByDate(queries),
+      ...sortQueries(queries),
     };
   };
 }

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -111,7 +111,7 @@ export function sortQueries({
   return {
     verify: verify.sort(
       (a, b) =>
-        (b.livenessEndsMilliseconds || 0) - (a.livenessEndsMilliseconds || 0)
+        (a.livenessEndsMilliseconds || 0) - (b.livenessEndsMilliseconds || 0)
     ),
     propose: propose.sort(
       (a, b) => (b.timeMilliseconds || 0) - (a.timeMilliseconds || 0)

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -97,7 +97,7 @@ export function makeFilterTitle(filterName: string) {
   return capitalize(words(filterName)[0]);
 }
 
-export function sortQueriesByDate({
+export function sortQueries({
   verify,
   propose,
   settled,
@@ -106,9 +106,12 @@ export function sortQueriesByDate({
   propose: OracleQueryList;
   settled: OracleQueryList;
 }) {
+  // propose and settled are sorted by the time the query was created
+  // verify is sorted by when the liveness ends, so that the ones that end soonest are easy to find
   return {
     verify: verify.sort(
-      (a, b) => (b.timeMilliseconds || 0) - (a.timeMilliseconds || 0)
+      (a, b) =>
+        (b.livenessEndsMilliseconds || 0) - (a.livenessEndsMilliseconds || 0)
     ),
     propose: propose.sort(
       (a, b) => (b.timeMilliseconds || 0) - (a.timeMilliseconds || 0)

--- a/src/stories/pages/Verify.stories.tsx
+++ b/src/stories/pages/Verify.stories.tsx
@@ -7,8 +7,10 @@ import {
   handlersWithNoData,
   makeEtherValueString,
   makeGraphqlHandlers,
+  makeMockAssertions,
   makeMockRequestGraphEntities,
   makeMockRouterPathname,
+  makeUnixTimestamp,
 } from "../mocks";
 import { NotificationsDecorator, Template } from "./shared";
 import type { PageStory } from "./types";
@@ -89,6 +91,80 @@ export const WithLongTitles: PageStory = {
                 state: "Proposed",
                 proposedPrice: makeEtherValueString(123),
               },
+            ],
+          }),
+        },
+      }),
+    },
+  },
+};
+
+export const WithDifferentExpirations: PageStory = {
+  ...VerifyTemplate,
+  parameters: {
+    ...VerifyTemplate.parameters,
+    msw: {
+      handlers: makeGraphqlHandlers({
+        v2: {
+          Ethereum: makeMockRequestGraphEntities({
+            inputs: [
+              {
+                state: "Proposed",
+                proposedPrice: makeEtherValueString(123),
+                proposalExpirationTimestamp: makeUnixTimestamp("future", {
+                  hours: 1,
+                }),
+              },
+              {
+                state: "Proposed",
+                proposedPrice: makeEtherValueString(123),
+                proposalExpirationTimestamp: makeUnixTimestamp("future", {
+                  hours: 2,
+                }),
+              },
+              {
+                state: "Proposed",
+                proposedPrice: makeEtherValueString(123),
+                proposalExpirationTimestamp: makeUnixTimestamp("future", {
+                  hours: 3,
+                }),
+              },
+            ],
+          }),
+        },
+        skinny: {
+          Ethereum: makeMockRequestGraphEntities({
+            inputs: [
+              {
+                state: "Proposed",
+                proposedPrice: makeEtherValueString(123),
+                proposalExpirationTimestamp: makeUnixTimestamp("future", {
+                  hours: 4,
+                }),
+              },
+              {
+                state: "Proposed",
+                proposedPrice: makeEtherValueString(123),
+                proposalExpirationTimestamp: makeUnixTimestamp("future", {
+                  hours: 5,
+                }),
+              },
+              {
+                state: "Proposed",
+                proposedPrice: makeEtherValueString(123),
+                proposalExpirationTimestamp: makeUnixTimestamp("future", {
+                  hours: 6,
+                }),
+              },
+            ],
+          }),
+        },
+        v3: {
+          Ethereum: makeMockAssertions({
+            inputs: [
+              { expirationTime: makeUnixTimestamp("future", { hours: 7 }) },
+              { expirationTime: makeUnixTimestamp("future", { hours: 8 }) },
+              { expirationTime: makeUnixTimestamp("future", { hours: 9 }) },
             ],
           }),
         },


### PR DESCRIPTION
Sort verify page queries by liveness ends when loading them in the OracleDataContext.

**[Story](https://www.chromatic.com/component?appId=63d101d13121a53332f6218c&csfId=pages-verify--with-different-expirations&buildNumber=71&k=64464506865ea7d129a70eb6-320-interactive-true&h=12&b=-4)**