### PR TITLE
fix: add usePagination hook to avoid wrong initial values

### DIFF
--- a/src/components/OracleQueryList/OracleQueryList.tsx
+++ b/src/components/OracleQueryList/OracleQueryList.tsx
@@ -26,7 +26,7 @@ export function OracleQueryList({
   isLoading,
   findQueryIndex,
 }: Props) {
-  const [itemsToShow, setItemsToShow] = useState(items);
+  const [itemsToShow, setItemsToShow] = useState<typeof items>([]);
 
   useEffect(() => {
     if (items.length <= defaultResultsPerPage) {

--- a/src/components/OracleQueryList/OracleQueryList.tsx
+++ b/src/components/OracleQueryList/OracleQueryList.tsx
@@ -1,9 +1,8 @@
 import { defaultResultsPerPage } from "@/constants";
 import type { OracleQueryUI } from "@/types";
 import type { PageName } from "@shared/types";
-import { useEffect, useState } from "react";
 import styled from "styled-components";
-import { Pagination } from "../Pagination";
+import { Pagination, usePagination } from "@/components";
 import { Item } from "./Item";
 import { LoadingItem } from "./LoadingItem";
 
@@ -19,6 +18,7 @@ interface Props {
  * @param page The page the queries are being rendered on.
  * @param items The queries to render.
  * @param isLoading Whether the queries are still loading.
+ * @param findQueryIndex - the index of the query from the url, if any
  */
 export function OracleQueryList({
   page,
@@ -26,13 +26,11 @@ export function OracleQueryList({
   isLoading,
   findQueryIndex,
 }: Props) {
-  const [itemsToShow, setItemsToShow] = useState<typeof items>([]);
+  const { entriesToShow, ...paginationProps } = usePagination(
+    items,
+    findQueryIndex
+  );
 
-  useEffect(() => {
-    if (items.length <= defaultResultsPerPage) {
-      setItemsToShow(items);
-    }
-  }, [items]);
   return (
     <Wrapper>
       <Title>Query</Title>
@@ -44,18 +42,14 @@ export function OracleQueryList({
         </>
       ) : (
         <>
-          {itemsToShow.map((item) => (
+          {entriesToShow.map((item) => (
             <Item key={item.id} page={page} item={item} />
           ))}
         </>
       )}
       {items.length > defaultResultsPerPage && !isLoading && (
         <PaginationWrapper>
-          <Pagination
-            entries={items}
-            setEntriesToShow={setItemsToShow}
-            findIndex={findQueryIndex}
-          />
+          <Pagination {...paginationProps} />
         </PaginationWrapper>
       )}
     </Wrapper>

--- a/src/components/OracleQueryTable/OracleQueryTable.tsx
+++ b/src/components/OracleQueryTable/OracleQueryTable.tsx
@@ -1,9 +1,8 @@
 import { defaultResultsPerPage } from "@/constants";
 import type { OracleQueryUI } from "@/types";
 import type { PageName } from "@shared/types";
-import { useEffect, useState } from "react";
 import styled from "styled-components";
-import { Pagination } from "../Pagination";
+import { Pagination, usePagination } from "@/components";
 import { Headers } from "./Headers";
 import { LoadingRow } from "./LoadingRow";
 import { Row } from "./Row";
@@ -20,6 +19,7 @@ interface Props {
  * @param page - the page of the app, used to determine which columns to show
  * @param rows - the rows to show in the table
  * @param isLoading - whether the table is loading
+ * @param findQueryIndex - the index of the query from the url, if any
  */
 export function OracleQueryTable({
   page,
@@ -27,13 +27,10 @@ export function OracleQueryTable({
   isLoading,
   findQueryIndex,
 }: Props) {
-  const [rowsToShow, setRowsToShow] = useState<typeof rows>([]);
-
-  useEffect(() => {
-    if (rows.length <= defaultResultsPerPage) {
-      setRowsToShow(rows);
-    }
-  }, [rows]);
+  const { entriesToShow, ...paginationProps } = usePagination(
+    rows,
+    findQueryIndex
+  );
 
   return (
     <Wrapper>
@@ -49,7 +46,7 @@ export function OracleQueryTable({
             </>
           ) : (
             <>
-              {rowsToShow.map((row) => (
+              {entriesToShow.map((row) => (
                 <Row key={row.id} page={page} row={row} />
               ))}
             </>
@@ -58,11 +55,7 @@ export function OracleQueryTable({
       </_Table>
       {rows.length > defaultResultsPerPage && !isLoading && (
         <PaginationWrapper>
-          <Pagination
-            entries={rows}
-            setEntriesToShow={setRowsToShow}
-            findIndex={findQueryIndex}
-          />
+          <Pagination {...paginationProps} />
         </PaginationWrapper>
       )}
     </Wrapper>

--- a/src/components/OracleQueryTable/OracleQueryTable.tsx
+++ b/src/components/OracleQueryTable/OracleQueryTable.tsx
@@ -27,7 +27,7 @@ export function OracleQueryTable({
   isLoading,
   findQueryIndex,
 }: Props) {
-  const [rowsToShow, setRowsToShow] = useState(rows);
+  const [rowsToShow, setRowsToShow] = useState<typeof rows>([]);
 
   useEffect(() => {
     if (rows.length <= defaultResultsPerPage) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,7 +21,7 @@ export { Notifications } from "./Notifications";
 export { OracleQueries } from "./OracleQueries";
 export { OracleQueryList } from "./OracleQueryList/OracleQueryList";
 export { OracleQueryTable } from "./OracleQueryTable/OracleQueryTable";
-export { Pagination } from "./Pagination";
+export { Pagination, usePagination } from "./Pagination";
 export { Panel } from "./Panel/Panel";
 export { PanelBase } from "./Panel/PanelBase";
 export { RadioDropdown } from "./RadioDropdown";

--- a/src/stories/Pagination.stories.tsx
+++ b/src/stories/Pagination.stories.tsx
@@ -1,9 +1,8 @@
-import { Pagination } from "@/components";
+import { Pagination, usePagination } from "@/components";
 import { white } from "@/constants";
 import { expect } from "@storybook/jest";
 import type { Meta, StoryObj } from "@storybook/react";
 import { userEvent, waitFor, within } from "@storybook/testing-library";
-import { useState } from "react";
 
 const meta: Meta<typeof Pagination> = {
   component: Pagination,
@@ -24,14 +23,8 @@ function makeMockEntries(length: number) {
   }));
 }
 
-function Wrapper({
-  Component,
-  entries,
-}: {
-  Component: typeof Pagination;
-  entries: ReturnType<typeof makeMockEntries>;
-}) {
-  const [entriesToShow, setEntriesToShow] = useState(entries);
+function Wrapper({ entries }: { entries: ReturnType<typeof makeMockEntries> }) {
+  const { entriesToShow, ...paginationProps } = usePagination(entries);
 
   return (
     <div>
@@ -41,17 +34,14 @@ function Wrapper({
         </p>
       ))}
       <br />
-      <Component entries={entries} setEntriesToShow={setEntriesToShow} />
+      <Pagination {...paginationProps} />
     </div>
   );
 }
 
 const Template: Story = {
   render: ({ numberOfEntries }) => (
-    <Wrapper
-      Component={Pagination}
-      entries={makeMockEntries(numberOfEntries)}
-    />
+    <Wrapper entries={makeMockEntries(numberOfEntries)} />
   ),
 };
 


### PR DESCRIPTION
### Fix: it takes long to go from settled to propose/verify

This bug was caused by this logic:

`const [rowsToShow, setRowsToShow] = useState(rows);`

Using the `rows` as the initial state means that the component is first rendered with the entire list of unpaginated values. This first render happens before the `Pagination` component has a chance to render, which means that we attempt to render all several thousand of the entries on the first render.

Changing the code to:

``const [rowsToShow, setRowsToShow] = useState(rows);``

Fixes the issue. 

However, this component's api is in my opinion going to be a source of bugs, because the `entriesToShow` logic is duplicated in the components that use it, and its certainly possible that it would happen again in another usage of the component.

I've opted to change the api of the component, so that its now intended to be used with a `usePagination` hook which holds all the state (including the state that was previously being duplicated in component implementations) and returns all of the props for the `Pagination` component. I think this api is much cleaner, and it wraps up the code that was a source of bugs and stops it from being duplicated.

I chose to put the `usePagination` hook in the same file as the `Pagination` component because they are only intended to be used together. If this doesn't make sense, I'm happy to move it to the `hooks` directory with the other hooks.

The **[Stories](https://63d101d13121a53332f6218c-zqfjbovbxx.chromatic.com/?path=/story/stories-pagination--even-number-of-entries)** introduce no visual changes and pass all tests.