### PR TITLE
fix: add years months weeks and days to time format

### DIFF
--- a/src/components/LivenessProgressBar.tsx
+++ b/src/components/LivenessProgressBar.tsx
@@ -1,6 +1,6 @@
 import { darkText, red500 } from "@/constants";
 import { Indicator, Root } from "@radix-ui/react-progress";
-import { intervalToDuration } from "date-fns";
+import { formatDuration, intervalToDuration } from "date-fns";
 import { useState } from "react";
 import type { CSSProperties } from "styled-components";
 import styled, { css } from "styled-components";
@@ -40,14 +40,19 @@ export function LivenessProgressBar({
     start: now,
     end: endTimeAsDate,
   });
-  const { hours, minutes, seconds } = timeRemaining;
-  const timeRemainingString = `${hours && hours > 0 ? `${hours} h ` : ""}${
-    minutes && minutes > 0 ? `${minutes} m ` : ""
-  }${seconds ?? 0} s`;
+  const timeRemainingString = formatDuration(timeRemaining)
+    .replace("years", "y")
+    .replace("months", "mo")
+    .replace("weeks", "w")
+    .replace("days", "d")
+    .replace("hours", "h")
+    .replace("minutes", "m")
+    .replace("seconds", "s");
 
   const isEnded = endTimeAsDate < now;
 
-  const isTextRed = !hours || hours === 0 || isEnded;
+  const isTextRed =
+    !timeRemaining.hours || timeRemaining.hours === 0 || isEnded;
 
   return (
     <Wrapper>


### PR DESCRIPTION
When we format the time remaining in the liveness progress bar, we were only handling hours, minutes and seconds. This made the progress bar say that it was going to end in 4 hours, when it really meant to say that it was going to end in 4 days and 4 hours.

There's no direct way to format the duration the way we do in the designs, so I've instead used the `date-fns` format function and then replaced the years, months etc. in the string instead. Not the cleanest, but gets the job done without being overly complicated.