### PR TITLE
feat: fix regex for shortening time units

### DIFF
--- a/src/components/LivenessProgressBar.tsx
+++ b/src/components/LivenessProgressBar.tsx
@@ -41,13 +41,13 @@ export function LivenessProgressBar({
     end: endTimeAsDate,
   });
   const timeRemainingString = formatDuration(timeRemaining)
-    .replace(/y(ear)?s?/, "y")
-    .replace(/m(onth)?s?/, "mo")
-    .replace(/w(eek)?s?/, "w")
-    .replace(/d(ay)?s?/, "d")
-    .replace(/h(our)?s?/, "h")
-    .replace(/m(inute)?s?/, "m")
-    .replace(/s(econd)?s?/, "s");
+    .replace(/(year)s?/, "y")
+    .replace(/(month)s?/, "mo")
+    .replace(/(week)s?/, "w")
+    .replace(/(day)s?/, "d")
+    .replace(/(hour)s?/, "h")
+    .replace(/(minute)s?/, "m")
+    .replace(/(second)s?/, "s");
 
   const isEnded = endTimeAsDate < now;
 


### PR DESCRIPTION
## motivation
we had a mispelling of minutes

## changes
turns out the regex for "m(onth)?" was matching with minutes because the second block was optional, this changes regex to match the full word with only the `s` optional 

![image](https://user-images.githubusercontent.com/4429761/234616149-52bfd972-a8f6-4d08-9e1f-d0230a7093c1.png)
