### PR TITLE
feat: add additional timestamps

### DIFF
--- a/src/components/Panel/Details.tsx
+++ b/src/components/Panel/Details.tsx
@@ -17,6 +17,12 @@ import {
 export function Details({
   timeUTC,
   timeUNIX,
+  proposalTimeUTC,
+  proposalTimeUNIX,
+  settlementTimeUTC,
+  settlementTimeUNIX,
+  disputeTimeUTC,
+  disputeTimeUNIX,
   description,
   queryText,
   queryTextHex,
@@ -29,12 +35,46 @@ export function Details({
           <TimestampIcon />
           <SectionTitle>Timestamp</SectionTitle>
         </SectionTitleWrapper>
+        <SectionSubTitle>Requested Time</SectionSubTitle>
         <Text>
           <TimeFormat>UTC</TimeFormat> {timeUTC}
         </Text>
         <Text>
           <TimeFormat>UNIX</TimeFormat> {timeUNIX}
         </Text>
+        {proposalTimeUTC && proposalTimeUNIX ? (
+          <>
+            <SectionSubTitle>Proposed Time</SectionSubTitle>
+            <Text>
+              <TimeFormat>UTC</TimeFormat> {proposalTimeUTC}
+            </Text>
+            <Text>
+              <TimeFormat>UNIX</TimeFormat> {proposalTimeUNIX}
+            </Text>
+          </>
+        ) : null}
+        {disputeTimeUTC && disputeTimeUNIX ? (
+          <>
+            <SectionSubTitle>Disputed Time</SectionSubTitle>
+            <Text>
+              <TimeFormat>UTC</TimeFormat> {disputeTimeUTC}
+            </Text>
+            <Text>
+              <TimeFormat>UNIX</TimeFormat> {disputeTimeUNIX}
+            </Text>
+          </>
+        ) : null}
+        {settlementTimeUTC && settlementTimeUNIX ? (
+          <>
+            <SectionSubTitle>Settled Time</SectionSubTitle>
+            <Text>
+              <TimeFormat>UTC</TimeFormat> {settlementTimeUTC}
+            </Text>
+            <Text>
+              <TimeFormat>UNIX</TimeFormat> {settlementTimeUNIX}
+            </Text>
+          </>
+        ) : null}
       </DetailWrapper>
       <DetailWrapper>
         <SectionTitleWrapper>

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -727,18 +727,29 @@ export function requestToOracleQuery(request: Request): OracleQueryUI {
   if (currency) {
     result.tokenAddress = currency;
   }
-  if (exists(proposalTimestamp)) result.proposalTimestamp = proposalTimestamp;
+  if (exists(proposalTimestamp)) {
+    result.proposalTimeUTC = toTimeUTC(proposalTimestamp);
+    result.proposalTimeUNIX = toTimeUnix(proposalTimestamp);
+    result.proposalTimestamp = proposalTimestamp;
+  }
   if (exists(proposalHash)) result.proposalHash = proposalHash;
   if (exists(proposalLogIndex)) result.proposalLogIndex = proposalLogIndex;
   if (exists(requester)) result.requester = requester;
   if (exists(requestTimestamp)) result.requestTimestamp = requestTimestamp;
   if (exists(requestHash)) result.requestHash = requestHash;
   if (exists(requestLogIndex)) result.requestLogIndex = requestLogIndex;
-  if (exists(disputeTimestamp)) result.disputeTimestamp = disputeTimestamp;
+  if (exists(disputeTimestamp)) {
+    result.disputeTimeUTC = toTimeUTC(disputeTimestamp);
+    result.disputeTimeUNIX = toTimeUnix(disputeTimestamp);
+    result.disputeTimestamp = disputeTimestamp;
+  }
   if (exists(disputeHash)) result.disputeHash = disputeHash;
   if (exists(disputeLogIndex)) result.disputeLogIndex = disputeLogIndex;
-  if (exists(settlementTimestamp))
+  if (exists(settlementTimestamp)) {
+    result.settlementTimeUTC = toTimeUTC(settlementTimestamp);
+    result.settlementTimeUNIX = toTimeUnix(settlementTimestamp);
     result.settlementTimestamp = settlementTimestamp;
+  }
   if (exists(settlementHash)) result.settlementHash = settlementHash;
   if (exists(settlementLogIndex))
     result.settlementLogIndex = settlementLogIndex;
@@ -935,14 +946,20 @@ ${rulesRegex[1]}`;
     result.timeFormatted = toTimeFormatted(assertionTimestamp);
     result.assertionTimestamp = assertionTimestamp;
   }
-
   if (exists(assertionHash)) result.assertionHash = assertionHash;
   if (exists(assertionLogIndex)) result.assertionLogIndex = assertionLogIndex;
-  if (exists(disputeTimestamp)) result.disputeTimestamp = disputeTimestamp;
+  if (exists(disputeTimestamp)) {
+    result.disputeTimeUTC = toTimeUTC(disputeTimestamp);
+    result.disputeTimeUNIX = toTimeUnix(disputeTimestamp);
+    result.disputeTimestamp = disputeTimestamp;
+  }
   if (exists(disputeHash)) result.disputeHash = disputeHash;
   if (exists(disputeLogIndex)) result.disputeLogIndex = disputeLogIndex;
-  if (exists(settlementTimestamp))
+  if (exists(settlementTimestamp)) {
+    result.settlementTimeUTC = toTimeUTC(settlementTimestamp);
+    result.settlementTimeUNIX = toTimeUnix(settlementTimestamp);
     result.settlementTimestamp = settlementTimestamp;
+  }
   if (exists(settlementHash)) result.settlementHash = settlementHash;
   if (exists(settlementLogIndex))
     result.settlementLogIndex = settlementLogIndex;

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -81,6 +81,12 @@ export type OracleQueryUI = {
   timeUNIX?: number;
   timeMilliseconds?: number;
   timeFormatted?: string;
+  proposalTimeUTC?: string;
+  proposalTimeUNIX?: number;
+  settlementTimeUTC?: string;
+  settlementTimeUNIX?: number;
+  disputeTimeUNIX?: number;
+  disputeTimeUTC?: string;
   livenessEndsMilliseconds?: number;
   formattedLivenessEndsIn?: string;
   actionType: ActionType | null;


### PR DESCRIPTION
## motivation
we arent able to view the proposal timestamp on v1/v2 requests, this is used for setting up discord thread for evidence rational

## changes
this adds parsing for all lifecycle timestamps, depending on if they exist: request, proposal, dispute, settled.
 
![image](https://user-images.githubusercontent.com/4429761/235147557-d86f97a9-e72a-4b13-8ee0-d892f196bd79.png)
![image](https://user-images.githubusercontent.com/4429761/235147755-3da8282b-4553-4517-a0da-30a2e72ab9a6.png)
