### PR TITLE
improve: prevent site locking from search

### DIFF
--- a/src/constants/filters.ts
+++ b/src/constants/filters.ts
@@ -9,8 +9,6 @@ export const keys: (keyof OracleQueryUI)[] = [
   "description",
   "expiryType",
   "identifier",
-  "queryTextHex",
-  "queryText",
   "valueText",
   "timeUTC",
   "timeFormatted",

--- a/src/hooks/filters.ts
+++ b/src/hooks/filters.ts
@@ -11,6 +11,7 @@ import type {
 import Fuse from "fuse.js";
 import { cloneDeep } from "lodash";
 import { useEffect, useMemo, useReducer, useState } from "react";
+import { useDebounce } from "usehooks-ts";
 
 /**
  * Combines the filter and search hooks
@@ -34,6 +35,7 @@ export function useFilterAndSearch(queries: OracleQueryUI[] | undefined = []) {
  */
 export function useSearch(queries: OracleQueryUI[]) {
   const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearchTerm = useDebounce(searchTerm, 500);
 
   const fuse = useMemo(() => {
     return new Fuse(queries, {
@@ -44,12 +46,10 @@ export function useSearch(queries: OracleQueryUI[]) {
   }, [queries]);
 
   const results = useMemo(() => {
-    if (!searchTerm) return queries;
-
-    const results = fuse.search(searchTerm);
-
+    if (!debouncedSearchTerm) return queries;
+    const results = fuse.search(debouncedSearchTerm);
     return results.map((result) => result.item);
-  }, [queries, fuse, searchTerm]);
+  }, [queries, fuse, debouncedSearchTerm]);
 
   return {
     results,


### PR DESCRIPTION
## motivation
if trying to search large strings, the site locks up on settled page since there are so many entries and long strings

## changes
this removes some redundant search fields which contain long strings, related to ancillary data, and adds a debounce for the input box so search is not executed on every change, it waits 500ms for user to stop typing. 