### PR TITLE
fix: prioritize in liveness queries on verify page

### DIFF
--- a/src/stories/pages/Verify.stories.tsx
+++ b/src/stories/pages/Verify.stories.tsx
@@ -129,6 +129,27 @@ export const WithDifferentExpirations: PageStory = {
                   hours: 3,
                 }),
               },
+              {
+                state: "Proposed",
+                proposedPrice: makeEtherValueString(123),
+                time: makeUnixTimestamp("past", {
+                  hours: 6,
+                }),
+                proposalExpirationTimestamp: makeUnixTimestamp("past", {
+                  hours: 1,
+                }),
+              },
+              {
+                state: "Proposed",
+                proposedPrice: makeEtherValueString(123),
+                disputeHash: "0x1234567890123456",
+                time: makeUnixTimestamp("past", {
+                  hours: 5,
+                }),
+                proposalExpirationTimestamp: makeUnixTimestamp("future", {
+                  hours: 1,
+                }),
+              },
             ],
           }),
         },
@@ -156,6 +177,27 @@ export const WithDifferentExpirations: PageStory = {
                   hours: 6,
                 }),
               },
+              {
+                state: "Proposed",
+                proposedPrice: makeEtherValueString(123),
+                time: makeUnixTimestamp("past", {
+                  hours: 4,
+                }),
+                proposalExpirationTimestamp: makeUnixTimestamp("past", {
+                  hours: 6,
+                }),
+              },
+              {
+                state: "Proposed",
+                proposedPrice: makeEtherValueString(123),
+                disputeHash: "0x1234567890123456",
+                time: makeUnixTimestamp("past", {
+                  hours: 3,
+                }),
+                proposalExpirationTimestamp: makeUnixTimestamp("future", {
+                  hours: 6,
+                }),
+              },
             ],
           }),
         },
@@ -165,6 +207,19 @@ export const WithDifferentExpirations: PageStory = {
               { expirationTime: makeUnixTimestamp("future", { hours: 7 }) },
               { expirationTime: makeUnixTimestamp("future", { hours: 8 }) },
               { expirationTime: makeUnixTimestamp("future", { hours: 9 }) },
+              {
+                disputeHash: "0x1234567890123456",
+                assertionTimestamp: makeUnixTimestamp("past", {
+                  hours: 2,
+                }),
+                expirationTime: makeUnixTimestamp("future", { hours: 9 }),
+              },
+              {
+                assertionTimestamp: makeUnixTimestamp("past", {
+                  hours: 2,
+                }),
+                expirationTime: makeUnixTimestamp("past", { hours: 9 }),
+              },
             ],
           }),
         },


### PR DESCRIPTION
Update the sorting logic for queries on the `verify` page to be more useful by separating out `inLiveness` and `notInLiveness` queries.

If a query has a `disputeHash` property then it is considered "disputed" and is therefore not in liveness.
If a query's `livenessEndsMilliseconds` property is in the past then the query is not in liveness.

We separate the queries before sorting.

We sort the `inLiveness` queries by `livenessEndsMilliseconds` in descending order so that the ones that expire soonest are at the top.

We sort the `notInLiveness` by `timeMilliseconds` (same as for other pages) because since they are not in liveness, the time that the liveness ends is no longer relevant.

Finally, we combine these two arrays such that the whole list of in liveness queries is shown first, and the rest come after.

I've updated **[this story](https://63d101d13121a53332f6218c-zzghnewlse.chromatic.com/?path=/story/pages-verify--with-different-expirations)** to demonstrate this behavior.
