### PR TITLE
feat: include chain icon in table

### DIFF
--- a/src/components/ChainNameAndIcon.tsx
+++ b/src/components/ChainNameAndIcon.tsx
@@ -1,0 +1,29 @@
+import { getChainIcon } from "@/constants";
+import type { ChainId, ChainName } from "@shared/types";
+import styled from "styled-components";
+
+interface Props {
+  chainName: ChainName;
+  chainId: ChainId;
+}
+export function ChainNameAndIcon({ chainName, chainId }: Props) {
+  const chainIcon = getChainIcon(chainId);
+
+  return (
+    <Wrapper>
+      <IconWrapper>{chainIcon}</IconWrapper> {chainName}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.span`
+  display: inline-flex;
+  align-items: center;
+  margin-right: 2px;
+  margin-left: 3px;
+`;
+
+const IconWrapper = styled.span`
+  width: 14px;
+  margin-right: 3px;
+`;

--- a/src/components/ChainNameAndIcon.tsx
+++ b/src/components/ChainNameAndIcon.tsx
@@ -18,12 +18,14 @@ export function ChainNameAndIcon({ chainName, chainId }: Props) {
 
 const Wrapper = styled.span`
   display: inline-flex;
-  align-items: center;
+  align-items: baseline;
   margin-right: 2px;
   margin-left: 3px;
 `;
 
 const IconWrapper = styled.span`
+  display: inline-block;
+  align-self: center;
   width: 14px;
   margin-right: 3px;
 `;

--- a/src/components/OracleQueryList/ItemTitle.tsx
+++ b/src/components/OracleQueryList/ItemTitle.tsx
@@ -1,4 +1,4 @@
-import { TruncatedTitle } from "@/components";
+import { ChainNameAndIcon, TruncatedTitle } from "@/components";
 import { getProjectIcon } from "@/constants";
 import type { OracleQueryUI } from "@/types";
 import {
@@ -13,6 +13,7 @@ export function ItemTitle({
   title,
   project,
   chainName,
+  chainId,
   timeFormatted,
   expiryType,
 }: OracleQueryUI) {
@@ -29,7 +30,9 @@ export function ItemTitle({
       </HeaderWrapper>
       <TitleText>
         {isKnownProject && `${project} | `}
-        {timeFormatted} | {chainName} {expiryType && `| ${expiryType}`}
+        {timeFormatted} |{" "}
+        <ChainNameAndIcon chainId={chainId} chainName={chainName} />{" "}
+        {expiryType && `| ${expiryType}`}
       </TitleText>
     </TitleWrapper>
   );

--- a/src/components/OracleQueryTable/TitleCell.tsx
+++ b/src/components/OracleQueryTable/TitleCell.tsx
@@ -1,5 +1,6 @@
 import { getProjectIcon } from "@/constants";
 import type { OracleQueryUI } from "@/types";
+import { ChainNameAndIcon } from "../ChainNameAndIcon";
 import { TruncatedTitle } from "../TruncatedTitle";
 import {
   IconWrapper,
@@ -24,6 +25,7 @@ export function TitleCell({
   title,
   project,
   chainName,
+  chainId,
   timeFormatted,
   expiryType,
 }: OracleQueryUI) {
@@ -40,7 +42,9 @@ export function TitleCell({
           </TitleHeader>
           <TitleText>
             {isKnownProject && `${project} | `}
-            {timeFormatted} | {chainName} {expiryType && `| ${expiryType}`}
+            {timeFormatted} |{" "}
+            <ChainNameAndIcon chainId={chainId} chainName={chainName} />{" "}
+            {expiryType && `| ${expiryType}`}
           </TitleText>
         </TextWrapper>
       </TitleWrapper>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { Button } from "./Button";
+export { ChainNameAndIcon } from "./ChainNameAndIcon";
 export { Checkbox } from "./Checkbox";
 export { CheckboxDropdown } from "./CheckboxDropdown";
 export { CheckboxList } from "./CheckboxList";


### PR DESCRIPTION
Add a `ChainNameAndIcon` component that shows a chain's icon next to its name.

<img width="297" alt="Screenshot 2023-05-04 at 09 23 47" src="https://user-images.githubusercontent.com/39741965/236137312-9656184f-fba5-4bf9-b2d8-ba6b78ddbf90.png">
