### PR TITLE
feat: handle graph failures in queries

### DIFF
--- a/libs/src/oracle-sdk-v2/services/oracles/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oracles/factory.ts
@@ -1,4 +1,4 @@
-import type { ChainId, OracleType } from "@shared/types";
+import type { ChainId, ErrorMessage, OracleType } from "@shared/types";
 import type { Handlers, Service, ServiceFactory } from "../../types";
 
 // gql1 covers skinny, v1, v2
@@ -11,6 +11,7 @@ export type GqlConfig = {
   chainId: ChainId;
   type: OracleType;
   address: string;
+  addErrorMessage: (message: ErrorMessage) => void;
 };
 export type Config = GqlConfig[];
 

--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/factory.ts
@@ -1,4 +1,4 @@
-import type { ChainId, OracleType } from "@shared/types";
+import type { ChainId, ErrorMessage, OracleType } from "@shared/types";
 import { parsePriceRequestGraphEntity } from "@shared/utils";
 import type { Address } from "wagmi";
 import type { Handlers, Service, ServiceFactory } from "../../../types";
@@ -9,13 +9,25 @@ export type Config = {
   chainId: ChainId;
   address: string;
   type: OracleType;
+  addErrorMessage: (message: ErrorMessage) => void;
 };
 
 export const Factory =
   (config: Config): ServiceFactory =>
   (handlers: Handlers): Service => {
-    async function fetch({ url, chainId, address, type }: Config) {
-      const requests = await getPriceRequests(url, chainId, type);
+    async function fetch({
+      url,
+      chainId,
+      address,
+      type,
+      addErrorMessage,
+    }: Config) {
+      const requests = await getPriceRequests(
+        url,
+        chainId,
+        type,
+        addErrorMessage
+      );
       return requests.map((request) =>
         parsePriceRequestGraphEntity(request, chainId, address as Address, type)
       );

--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
@@ -24,9 +24,9 @@ export async function getPriceRequests(
     return result;
   } catch (e) {
     addErrorMessage({
-      text: "TheGraph is experiencing downtime. Please use the legacy dapp while they rectify the issue",
+      text: "The Graph is experiencing downtime",
       link: {
-        text: "Legacy Dapp",
+        text: "Please use the Legacy Dapp",
         href: "https://legacy.oracle.uma.xyz",
       },
     });

--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
@@ -1,6 +1,7 @@
 import { chainsById } from "@shared/constants";
 import type {
   ChainId,
+  ErrorMessage,
   OOV1GraphEntity,
   OOV2GraphEntity,
   OracleType,
@@ -12,13 +13,25 @@ import request, { gql } from "graphql-request";
 export async function getPriceRequests(
   url: string,
   chainId: ChainId,
-  oracleType: OracleType
+  oracleType: OracleType,
+  addErrorMessage: (message: ErrorMessage) => void
 ) {
-  const chainName = chainsById[chainId];
-  const queryName = makeQueryName(oracleType, chainName);
-  const isV2 = oracleType === "Optimistic Oracle V2";
-  const result = await fetchAllRequests(url, queryName, isV2);
-  return result;
+  try {
+    const chainName = chainsById[chainId];
+    const queryName = makeQueryName(oracleType, chainName);
+    const isV2 = oracleType === "Optimistic Oracle V2";
+    const result = await fetchAllRequests(url, queryName, isV2);
+    return result;
+  } catch (e) {
+    addErrorMessage({
+      text: "TheGraph is experiencing downtime. Please use the legacy dapp while they rectify the issue",
+      link: {
+        text: "Legacy Dapp",
+        href: "https://legacy.oracle.uma.xyz",
+      },
+    });
+    return [];
+  }
 }
 
 async function fetchAllRequests(url: string, queryName: string, isV2: boolean) {
@@ -41,7 +54,12 @@ async function fetchAllRequests(url: string, queryName: string, isV2: boolean) {
 }
 
 async function fetchPriceRequests(url: string, query: string) {
-  const result = await request<PriceRequestsQuery>(url, query);
+  const result = await request<
+    PriceRequestsQuery | { errors: { message: string }[] }
+  >(url, query);
+  if ("errors" in result) {
+    throw new Error(result.errors[0].message);
+  }
   return result.optimisticPriceRequests;
 }
 

--- a/libs/src/oracle-sdk-v2/services/oraclev3/gql/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/gql/factory.ts
@@ -1,4 +1,4 @@
-import type { ChainId } from "@shared/types";
+import type { ChainId, ErrorMessage } from "@shared/types";
 import { parseAssertionGraphEntity } from "@shared/utils";
 import type { Address } from "wagmi";
 import type { Handlers, Service, ServiceFactory } from "../../../types";
@@ -8,13 +8,14 @@ export type Config = {
   url: string;
   chainId: ChainId;
   address: string;
+  addErrorMessage: (message: ErrorMessage) => void;
 };
 
 export const Factory =
   (config: Config): ServiceFactory =>
   (handlers: Handlers): Service => {
-    async function fetch({ url, chainId, address }: Config) {
-      const requests = await getAssertions(url, chainId);
+    async function fetch({ url, chainId, address, addErrorMessage }: Config) {
+      const requests = await getAssertions(url, chainId, addErrorMessage);
       return requests.map((request) =>
         parseAssertionGraphEntity(request, chainId, address as Address)
       );

--- a/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
@@ -1,13 +1,33 @@
 import { chainsById } from "@shared/constants";
-import type { ChainId, OOV3GraphEntity, OOV3GraphQuery } from "@shared/types";
+import type {
+  ChainId,
+  ErrorMessage,
+  OOV3GraphEntity,
+  OOV3GraphQuery,
+} from "@shared/types";
 import { makeQueryName } from "@shared/utils";
 import request, { gql } from "graphql-request";
 
-export async function getAssertions(url: string, chainId: ChainId) {
-  const chainName = chainsById[chainId];
-  const queryName = makeQueryName("Optimistic Oracle V3", chainName);
-  const result = await fetchAllAssertions(url, queryName);
-  return result;
+export async function getAssertions(
+  url: string,
+  chainId: ChainId,
+  addErrorMessage: (message: ErrorMessage) => void
+) {
+  try {
+    const chainName = chainsById[chainId];
+    const queryName = makeQueryName("Optimistic Oracle V3", chainName);
+    const result = await fetchAllAssertions(url, queryName);
+    return result;
+  } catch (e) {
+    addErrorMessage({
+      text: "TheGraph is experiencing downtime. Please use the legacy dapp while they rectify the issue",
+      link: {
+        text: "Legacy Dapp",
+        href: "https://legacy.oracle.uma.xyz",
+      },
+    });
+    return [];
+  }
 }
 
 async function fetchAllAssertions(url: string, queryName: string) {

--- a/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
@@ -20,9 +20,9 @@ export async function getAssertions(
     return result;
   } catch (e) {
     addErrorMessage({
-      text: "TheGraph is experiencing downtime. Please use the legacy dapp while they rectify the issue",
+      text: "The Graph is experiencing downtime",
       link: {
-        text: "Legacy Dapp",
+        text: "Please use the Legacy Dapp",
         href: "https://legacy.oracle.uma.xyz",
       },
     });

--- a/shared/types/oracle.ts
+++ b/shared/types/oracle.ts
@@ -74,3 +74,11 @@ export type Transaction = {
   error?: Error;
 };
 export type Transactions = Transaction[];
+
+export type ErrorMessage = {
+  text: string;
+  link?: {
+    text: string;
+    href: string;
+  };
+};

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,5 +1,5 @@
 import { mobileAndUnder } from "@/constants";
-import type { ErrorMessage as ErrorMessageType } from "@/types";
+import type { ErrorMessage as ErrorMessageType } from "@shared/types";
 import NextLink from "next/link";
 import styled from "styled-components";
 

--- a/src/contexts/ErrorContext.tsx
+++ b/src/contexts/ErrorContext.tsx
@@ -1,4 +1,4 @@
-import type { ErrorMessage } from "@/types";
+import type { ErrorMessage } from "@shared/types";
 import type { ReactNode } from "react";
 import { createContext, useState } from "react";
 

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -6,6 +6,7 @@ import {
   requestToOracleQuery,
   sortQueries,
 } from "@/helpers";
+import { useErrorContext } from "@/hooks";
 import type { OracleQueryUI } from "@/types";
 import type { ServiceFactories, ServiceFactory } from "@libs/oracle-sdk-v2";
 import { Client } from "@libs/oracle-sdk-v2";
@@ -28,8 +29,6 @@ import type {
 import unionWith from "lodash/unionWith";
 import type { ReactNode } from "react";
 import { createContext, useEffect, useReducer, useState } from "react";
-
-const oraclesService = oracles.Factory(config.subgraphs);
 
 //TODO: hate this approach, will need to refactor in future, current services interface does not make it easy to define custom functions
 // this will be moved somewhere else in future pr.
@@ -67,7 +66,7 @@ const [oracleEthersServices, oracleEthersApis] = config.providers
   );
 
 // This exposes any api calls to services to other parts of app
-export { oraclesService, oracleEthersApis };
+export { oracleEthersApis };
 
 export type OracleQueryList = OracleQueryUI[];
 export type OracleQueryTable = Record<string, OracleQueryUI>;
@@ -172,6 +171,11 @@ export function oracleDataReducer(
   return state;
 }
 export function OracleDataProvider({ children }: { children: ReactNode }) {
+  const { addErrorMessage } = useErrorContext();
+  const oraclesService = oracles.Factory(
+    config.subgraphs.map((c) => ({ ...c, addErrorMessage }))
+  );
+
   const [queries, dispatch] = useReducer(
     oracleDataReducer,
     defaultOracleDataContextState

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,8 @@
 import { GlobalStyle, Layout } from "@/components";
 import {
-  chains as supportedChains,
   config,
   red500,
+  chains as supportedChains,
   walletsAndConnectors,
   white,
 } from "@/constants";
@@ -15,10 +15,10 @@ import {
   PanelProvider,
 } from "@/contexts";
 import "@/styles/fonts.css";
-import { darkTheme, RainbowKitProvider } from "@rainbow-me/rainbowkit";
+import { RainbowKitProvider, darkTheme } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
 import type { AppProps } from "next/app";
-import { configureChains, createClient, WagmiConfig } from "wagmi";
+import { WagmiConfig, configureChains, createClient } from "wagmi";
 import { infuraProvider } from "wagmi/providers/infura";
 import { publicProvider } from "wagmi/providers/public";
 
@@ -48,8 +48,8 @@ export default function App({ Component, pageProps }: AppProps) {
       <RainbowKitProvider chains={chains} theme={rainbowKitTheme}>
         <PageProvider>
           <NotificationsProvider>
-            <OracleDataProvider>
-              <ErrorProvider>
+            <ErrorProvider>
+              <OracleDataProvider>
                 <PanelProvider>
                   <FilterAndSearchProvider>
                     <Layout>
@@ -58,8 +58,8 @@ export default function App({ Component, pageProps }: AppProps) {
                     </Layout>
                   </FilterAndSearchProvider>
                 </PanelProvider>
-              </ErrorProvider>
-            </OracleDataProvider>
+              </OracleDataProvider>
+            </ErrorProvider>
           </NotificationsProvider>
         </PageProvider>
       </RainbowKitProvider>

--- a/src/stories/ErrorBanner.stories.tsx
+++ b/src/stories/ErrorBanner.stories.tsx
@@ -2,7 +2,7 @@ import { Button, ErrorBanner } from "@/components";
 import type { ErrorContextState } from "@/contexts";
 import { ErrorContext } from "@/contexts";
 import { parseEthersError } from "@/helpers";
-import type { ErrorMessage } from "@/types";
+import type { ErrorMessage } from "@shared/types";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import styled from "styled-components";

--- a/src/stories/pages/types.ts
+++ b/src/stories/pages/types.ts
@@ -2,7 +2,7 @@ import type { NotificationsById } from "@/contexts";
 import type VerifyPage from "@/pages";
 import type ProposePage from "@/pages/propose";
 import type SettledPage from "@/pages/settled";
-import type { ErrorMessage } from "@/types";
+import type { ErrorMessage } from "@shared/types";
 import type { StoryObj } from "@storybook/react";
 
 export type Page = typeof VerifyPage | typeof ProposePage | typeof SettledPage;

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -13,6 +13,7 @@ import type {
 import type {
   ChainId,
   ChainName,
+  ErrorMessage,
   ExpiryType,
   OracleType,
   Project,
@@ -351,14 +352,6 @@ export type MoreInformationItem = {
   title: string;
   text: string;
   href: string;
-};
-
-export type ErrorMessage = {
-  text: string;
-  link?: {
-    text: string;
-    href: string;
-  };
 };
 
 export type CheckboxState = DropdownMenuCheckboxItemProps["checked"];


### PR DESCRIPTION
Pass down an `addErrorMessage` function from the `ErrorContext` to the graphql queries so that they can show a global error in the event of a graph outage like the planned one coming up on Monday.

We don't know if the graph will simply throw a 500 error during this downtime, or if it will return an errors object like it normally would in the case of a query error. I've updated the functions to handle both cases.