### PR TITLE
fix: use settlement price instead of proposed price

### DIFF
--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -177,7 +177,7 @@ function getPriceRequestValueText(
   proposedPrice: BigNumber | null | undefined,
   settlementPrice: BigNumber | null | undefined
 ) {
-  const price = proposedPrice ?? settlementPrice;
+  const price = settlementPrice ?? proposedPrice;
   if (price === null || price === undefined) return null;
   return formatNumberForDisplay(price, { isFormatEther: true });
 }


### PR DESCRIPTION
We have some backwards logic that lead to a bug. I'm quite surprised we have only noticed the problem now.

In our `converters`, we have a function that gets the text to display for a request's price. In that code, we were doing `proposedPrice ?? settlementPrice`, which would use the proposed price if it exists, and the settlement price if not. This is the opposite of what we want of course — if the settlement price exists, then that is the one we want to display.