### PR TITLE
feat: add web3 fallback for querying data if graph down

### DIFF
--- a/libs/src/clients/optimisticOracleV3/client.ts
+++ b/libs/src/clients/optimisticOracleV3/client.ts
@@ -96,7 +96,7 @@ export function reduceEvents(
       if (!state.assertions) state.assertions = {};
       const assertion: Assertion = state.assertions[assertionId];
       const escalationManagerSettings: Partial<EscalationManagerSettings> =
-        assertion.escalationManagerSettings || {};
+        assertion?.escalationManagerSettings || {};
       state.assertions[assertionId] = {
         ...assertion,
         assertionId,

--- a/libs/src/oracle-sdk-v2/services/oracles/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oracles/factory.ts
@@ -1,4 +1,4 @@
-import type { ChainId, ErrorMessage, OracleType } from "@shared/types";
+import type { ChainId, OracleType } from "@shared/types";
 import type { Handlers, Service, ServiceFactory } from "../../types";
 
 // gql1 covers skinny, v1, v2
@@ -11,14 +11,12 @@ export type GqlConfig = {
   chainId: ChainId;
   type: OracleType;
   address: string;
-  addErrorMessage: (message: ErrorMessage) => void;
 };
 export type Config = GqlConfig[];
 
-export const Factory =
-  (config: Config): ServiceFactory =>
-  (handlers: Handlers): Service => {
-    const services: Service[] = config.map((config) => {
+export const Factory = (config: Config): ServiceFactory[] => {
+  return config.map((config) => {
+    return (handlers: Handlers): Service => {
       if (
         config.source === "gql" &&
         (config.type === "Optimistic Oracle V1" ||
@@ -33,15 +31,6 @@ export const Factory =
       throw new Error(
         `Unsupported oracle type ${config.type} from ${config.source}`
       );
-    });
-
-    async function tick() {
-      await Promise.all(
-        services.map(async (service) => (service ? service.tick() : undefined))
-      );
-    }
-
-    return {
-      tick,
     };
-  };
+  });
+};

--- a/libs/src/oracle-sdk-v2/services/oraclev1/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/ethers/factory.ts
@@ -1,7 +1,12 @@
 import Events from "events";
 import { ethers } from "ethers";
 import { assertAddress } from "@shared/utils";
-import { parseIdentifier } from "@libs/utils";
+import {
+  parseIdentifier,
+  rangeStart,
+  rangeSuccessDescending,
+  rangeFailureDescending,
+} from "@libs/utils";
 import type {
   Request as SharedRequest,
   OracleType,
@@ -34,6 +39,28 @@ function convertToSharedState(state: RequestState): SharedRequestState {
   if (state === RequestState.Resolved) return "Resolved";
   return "Settled";
 }
+
+// querying data from events does not provide timestamps for when events happen, at least not syncronously
+// we have to do block lookups to get block timestamps to associate with events 🤮
+const AddTimestamps =
+  (provider: ethers.providers.JsonRpcProvider) =>
+  async (request: SharedRequest): Promise<SharedRequest> => {
+    if (request.requestBlockNumber && !request.requestTimestamp) {
+      const block = await provider.getBlock(Number(request.requestBlockNumber));
+      request.requestTimestamp = block.timestamp.toString();
+    }
+    if (request.disputeBlockNumber && !request.disputeTimestamp) {
+      const block = await provider.getBlock(Number(request.disputeBlockNumber));
+      request.disputeTimestamp = block.timestamp.toString();
+    }
+    if (request.settlementBlockNumber && !request.settlementTimestamp) {
+      const block = await provider.getBlock(
+        Number(request.settlementBlockNumber)
+      );
+      request.settlementTimestamp = block.timestamp.toString();
+    }
+    return request;
+  };
 
 const ConvertToSharedRequest =
   (chainId: ChainId, oracleAddress: Address, oracleType: OracleType) =>
@@ -122,6 +149,7 @@ const ConvertToSharedRequest =
   };
 export type Api = {
   updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
+  queryLatestRequests?: (blocksAgo: number) => void;
 };
 export const Factory = (config: Config): [ServiceFactory, Api] => {
   const convertToSharedRequest = ConvertToSharedRequest(
@@ -132,6 +160,7 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
   const provider = new ethers.providers.JsonRpcProvider(config.url);
   const oo = new OptimisticOracle(provider, config.address, config.chainId);
   const events = new Events();
+  const addTimestamps = AddTimestamps(provider);
   function updateFromTransactionReceipt(receipt: TransactionReceipt) {
     try {
       oo.updateFromTransactionReceipt(receipt);
@@ -147,11 +176,45 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
   const service = (handlers: Handlers): Service => {
     if (handlers.requests) events.on("requests", handlers.requests);
   };
+  async function queryRange(startBlock: number, endBlock: number) {
+    let rangeState = rangeStart({ startBlock, endBlock });
+    const { currentStart, currentEnd } = rangeState;
+    try {
+      await oo.update(currentStart, currentEnd);
+      rangeState = rangeSuccessDescending({ ...rangeState, multiplier: 1 });
+    } catch (err) {
+      rangeState = rangeFailureDescending(rangeState);
+    }
+  }
+  function queryLatestRequests(blocksAgo: number) {
+    provider
+      .getBlockNumber()
+      .then(async (endBlock) => {
+        const startBlock = endBlock - blocksAgo;
+        await queryRange(startBlock, endBlock);
+        const requests = oo.listRequests();
+        const convertedRequests: SharedRequest[] = Object.values(requests).map(
+          convertToSharedRequest
+        );
+        const requestsWithTimestamps = await Promise.all(
+          convertedRequests.map(addTimestamps)
+        );
+        events.emit("requests", requestsWithTimestamps);
+      })
+      .catch((err) => {
+        console.warn(
+          "error querying latest OOV1 requests from web3 provider:",
+          err
+        );
+        events.emit("error", err);
+      });
+  }
 
   return [
     service,
     {
       updateFromTransactionReceipt,
+      queryLatestRequests,
     },
   ];
 };

--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/factory.ts
@@ -1,4 +1,4 @@
-import type { ChainId, ErrorMessage, OracleType } from "@shared/types";
+import type { ChainId, OracleType } from "@shared/types";
 import { parsePriceRequestGraphEntity } from "@shared/utils";
 import type { Address } from "wagmi";
 import type { Handlers, Service, ServiceFactory } from "../../../types";
@@ -9,25 +9,13 @@ export type Config = {
   chainId: ChainId;
   address: string;
   type: OracleType;
-  addErrorMessage: (message: ErrorMessage) => void;
 };
 
 export const Factory =
   (config: Config): ServiceFactory =>
   (handlers: Handlers): Service => {
-    async function fetch({
-      url,
-      chainId,
-      address,
-      type,
-      addErrorMessage,
-    }: Config) {
-      const requests = await getPriceRequests(
-        url,
-        chainId,
-        type,
-        addErrorMessage
-      );
+    async function fetch({ url, chainId, address, type }: Config) {
+      const requests = await getPriceRequests(url, chainId, type);
       return requests.map((request) =>
         parsePriceRequestGraphEntity(request, chainId, address as Address, type)
       );

--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
@@ -1,7 +1,6 @@
 import { chainsById } from "@shared/constants";
 import type {
   ChainId,
-  ErrorMessage,
   OOV1GraphEntity,
   OOV2GraphEntity,
   OracleType,
@@ -13,25 +12,13 @@ import request, { gql } from "graphql-request";
 export async function getPriceRequests(
   url: string,
   chainId: ChainId,
-  oracleType: OracleType,
-  addErrorMessage: (message: ErrorMessage) => void
+  oracleType: OracleType
 ) {
-  try {
-    const chainName = chainsById[chainId];
-    const queryName = makeQueryName(oracleType, chainName);
-    const isV2 = oracleType === "Optimistic Oracle V2";
-    const result = await fetchAllRequests(url, queryName, isV2);
-    return result;
-  } catch (e) {
-    addErrorMessage({
-      text: "The Graph is experiencing downtime",
-      link: {
-        text: "Please use the Legacy Dapp",
-        href: "https://legacy.oracle.uma.xyz",
-      },
-    });
-    return [];
-  }
+  const chainName = chainsById[chainId];
+  const queryName = makeQueryName(oracleType, chainName);
+  const isV2 = oracleType === "Optimistic Oracle V2";
+  const result = await fetchAllRequests(url, queryName, isV2);
+  return result;
 }
 
 async function fetchAllRequests(url: string, queryName: string, isV2: boolean) {

--- a/libs/src/oracle-sdk-v2/services/oraclev2/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev2/ethers/factory.ts
@@ -1,7 +1,12 @@
 import Events from "events";
 import { ethers } from "ethers";
 import { assertAddress } from "@shared/utils";
-import { parseIdentifier } from "@libs/utils";
+import {
+  parseIdentifier,
+  rangeStart,
+  rangeSuccessDescending,
+  rangeFailureDescending,
+} from "@libs/utils";
 import type {
   Request as SharedRequest,
   OracleType,
@@ -34,6 +39,28 @@ function convertToSharedState(state: RequestState): SharedRequestState {
   if (state === RequestState.Resolved) return "Resolved";
   return "Settled";
 }
+
+// querying data from events does not provide timestamps for when events happen, at least not syncronously
+// we have to do block lookups to get block timestamps to associate with events 🤮
+const AddTimestamps =
+  (provider: ethers.providers.JsonRpcProvider) =>
+  async (request: SharedRequest): Promise<SharedRequest> => {
+    if (request.requestBlockNumber && !request.requestTimestamp) {
+      const block = await provider.getBlock(Number(request.requestBlockNumber));
+      request.requestTimestamp = block.timestamp.toString();
+    }
+    if (request.disputeBlockNumber && !request.disputeTimestamp) {
+      const block = await provider.getBlock(Number(request.disputeBlockNumber));
+      request.disputeTimestamp = block.timestamp.toString();
+    }
+    if (request.settlementBlockNumber && !request.settlementTimestamp) {
+      const block = await provider.getBlock(
+        Number(request.settlementBlockNumber)
+      );
+      request.settlementTimestamp = block.timestamp.toString();
+    }
+    return request;
+  };
 
 const ConvertToSharedRequest =
   (chainId: ChainId, oracleAddress: Address, oracleType: OracleType) =>
@@ -122,6 +149,7 @@ const ConvertToSharedRequest =
   };
 export type Api = {
   updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
+  queryLatestRequests?: (blocksAgo: number) => void;
 };
 export const Factory = (config: Config): [ServiceFactory, Api] => {
   const convertToSharedRequest = ConvertToSharedRequest(
@@ -132,6 +160,7 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
   const provider = new ethers.providers.JsonRpcProvider(config.url);
   const oo = new OptimisticOracleV2(provider, config.address, config.chainId);
   const events = new Events();
+  const addTimestamps = AddTimestamps(provider);
   function updateFromTransactionReceipt(receipt: TransactionReceipt) {
     try {
       oo.updateFromTransactionReceipt(receipt);
@@ -147,11 +176,45 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
   const service = (handlers: Handlers): Service => {
     if (handlers.requests) events.on("requests", handlers.requests);
   };
+  async function queryRange(startBlock: number, endBlock: number) {
+    let rangeState = rangeStart({ startBlock, endBlock });
+    const { currentStart, currentEnd } = rangeState;
+    try {
+      await oo.update(currentStart, currentEnd);
+      rangeState = rangeSuccessDescending({ ...rangeState, multiplier: 1 });
+    } catch (err) {
+      rangeState = rangeFailureDescending(rangeState);
+    }
+  }
+  function queryLatestRequests(blocksAgo: number) {
+    provider
+      .getBlockNumber()
+      .then(async (endBlock) => {
+        const startBlock = endBlock - blocksAgo;
+        await queryRange(startBlock, endBlock);
+        const requests = oo.listRequests();
+        const convertedRequests: SharedRequest[] = Object.values(requests).map(
+          convertToSharedRequest
+        );
+        const requestsWithTimestamps = await Promise.all(
+          convertedRequests.map(addTimestamps)
+        );
+        events.emit("requests", requestsWithTimestamps);
+      })
+      .catch((err) => {
+        console.warn(
+          "error querying latest OOV2 requests from web3 provider:",
+          err
+        );
+        events.emit("error", err);
+      });
+  }
 
   return [
     service,
     {
       updateFromTransactionReceipt,
+      queryLatestRequests,
     },
   ];
 };

--- a/libs/src/oracle-sdk-v2/services/oraclev3/gql/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/gql/factory.ts
@@ -1,4 +1,4 @@
-import type { ChainId, ErrorMessage } from "@shared/types";
+import type { ChainId } from "@shared/types";
 import { parseAssertionGraphEntity } from "@shared/utils";
 import type { Address } from "wagmi";
 import type { Handlers, Service, ServiceFactory } from "../../../types";
@@ -8,14 +8,13 @@ export type Config = {
   url: string;
   chainId: ChainId;
   address: string;
-  addErrorMessage: (message: ErrorMessage) => void;
 };
 
 export const Factory =
   (config: Config): ServiceFactory =>
   (handlers: Handlers): Service => {
-    async function fetch({ url, chainId, address, addErrorMessage }: Config) {
-      const requests = await getAssertions(url, chainId, addErrorMessage);
+    async function fetch({ url, chainId, address }: Config) {
+      const requests = await getAssertions(url, chainId);
       return requests.map((request) =>
         parseAssertionGraphEntity(request, chainId, address as Address)
       );

--- a/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
@@ -1,33 +1,13 @@
 import { chainsById } from "@shared/constants";
-import type {
-  ChainId,
-  ErrorMessage,
-  OOV3GraphEntity,
-  OOV3GraphQuery,
-} from "@shared/types";
+import type { ChainId, OOV3GraphEntity, OOV3GraphQuery } from "@shared/types";
 import { makeQueryName } from "@shared/utils";
 import request, { gql } from "graphql-request";
 
-export async function getAssertions(
-  url: string,
-  chainId: ChainId,
-  addErrorMessage: (message: ErrorMessage) => void
-) {
-  try {
-    const chainName = chainsById[chainId];
-    const queryName = makeQueryName("Optimistic Oracle V3", chainName);
-    const result = await fetchAllAssertions(url, queryName);
-    return result;
-  } catch (e) {
-    addErrorMessage({
-      text: "The Graph is experiencing downtime",
-      link: {
-        text: "Please use the Legacy Dapp",
-        href: "https://legacy.oracle.uma.xyz",
-      },
-    });
-    return [];
-  }
+export async function getAssertions(url: string, chainId: ChainId) {
+  const chainName = chainsById[chainId];
+  const queryName = makeQueryName("Optimistic Oracle V3", chainName);
+  const result = await fetchAllAssertions(url, queryName);
+  return result;
 }
 
 async function fetchAllAssertions(url: string, queryName: string) {

--- a/libs/src/utils.ts
+++ b/libs/src/utils.ts
@@ -202,3 +202,122 @@ export function parseIdentifier(identifier: string | null | undefined): string {
   // replace non ascii chars
   return utf8.replace(/[^\x20-\x7E]+/g, "");
 }
+
+// This state is meant for adjusting a start/end block when querying events. Some apis will fail if the range
+// is too big, so the following functions will adjust range dynamically.
+export type RangeState = {
+  startBlock: number;
+  endBlock: number;
+  maxRange: number;
+  currentRange: number;
+  currentStart: number; // This is the start value you want for your query.
+  currentEnd: number; // this is the end value you want for your query.
+  done: boolean; // Signals we successfully queried the entire range.
+  multiplier?: number; // Multiplier increases or decreases range by this value, depending on success or failure
+};
+
+/**
+ * rangeStart. This starts a new range query and sets defaults for state.  Use this as the first call before starting your queries
+ *
+ * @param {Pick} state
+ * @returns {RangeState}
+ */
+export function rangeStart(
+  state: Pick<RangeState, "startBlock" | "endBlock" | "multiplier"> & {
+    maxRange?: number;
+  }
+): RangeState {
+  const { startBlock, endBlock, multiplier = 2 } = state;
+  if (state.maxRange && state.maxRange > 0) {
+    const range = endBlock - startBlock;
+    assert(range > 0, "End block must be higher than start block");
+    const currentRange = Math.min(state.maxRange, range);
+    const currentStart = endBlock - currentRange;
+    const currentEnd = endBlock;
+    return {
+      done: false,
+      startBlock,
+      endBlock,
+      maxRange: state.maxRange,
+      currentRange,
+      currentStart,
+      currentEnd,
+      multiplier,
+    };
+  } else {
+    // the largest range we can have, since this is the users query for start and end
+    const maxRange = endBlock - startBlock;
+    assert(maxRange > 0, "End block must be higher than start block");
+    const currentStart = startBlock;
+    const currentEnd = endBlock;
+    const currentRange = maxRange;
+
+    return {
+      done: false,
+      startBlock,
+      endBlock,
+      maxRange,
+      currentRange,
+      currentStart,
+      currentEnd,
+      multiplier,
+    };
+  }
+}
+/**
+ * rangeSuccessDescending. We have 2 ways of querying events, from oldest to newest, or newest to oldest. Typically we want them in order, from
+ * oldest to newest, but for this particular case we want them newest to oldest, ie descending ( larger timestamp to smaller timestamp).
+ * This function will increase the range between start/end block and return a new start/end to use since by calling this you are signalling
+ * that the last range ended in a successful query.
+ *
+ * @param {RangeState} state
+ * @returns {RangeState}
+ */
+export function rangeSuccessDescending(state: RangeState): RangeState {
+  const {
+    startBlock,
+    currentStart,
+    maxRange,
+    currentRange,
+    multiplier = 2,
+  } = state;
+  // we are done if we succeeded querying where the currentStart matches are initial start block
+  const done = currentStart <= startBlock;
+  // increase range up to max range for every successful query
+  const nextRange = Math.min(Math.ceil(currentRange * multiplier), maxRange);
+  // move our end point to the previously successful start, ie moving from newest to oldest
+  const nextEnd = currentStart;
+  // move our start block to the next range down
+  const nextStart = Math.max(nextEnd - nextRange, startBlock);
+  return {
+    ...state,
+    currentStart: nextStart,
+    currentEnd: nextEnd,
+    currentRange: nextRange,
+    done,
+  };
+}
+/**
+ * rangeFailureDescending. Like the previous function, this will decrease the range between start/end for your query, because you are signalling
+ * that the last query failed. It will also keep the end of your range the same, while moving the start range up. This is why
+ * its considered descending, it will attempt to move from end to start, rather than start to end.
+ *
+ * @param {RangeState} state
+ * @returns {RangeState}
+ */
+export function rangeFailureDescending(state: RangeState): RangeState {
+  const { startBlock, currentEnd, currentRange, multiplier = 2 } = state;
+  const nextRange = Math.floor(currentRange / multiplier);
+  // this will eventually throw an error if you keep calling this function, which protects us against re-querying a broken api in a loop
+  assert(nextRange > 0, "Range must be above 0");
+  // we stay at the same end block
+  const nextEnd = currentEnd;
+  // move our start block closer to the end block, shrinking the range
+  const nextStart = Math.max(nextEnd - nextRange, startBlock);
+  return {
+    ...state,
+    currentStart: nextStart,
+    currentEnd: nextEnd,
+    currentRange: nextRange,
+  };
+}

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -181,6 +181,7 @@ const ProviderConfig = ss.object({
   ]),
   url: ss.string(),
   address: ss.string(),
+  blockHistoryLimit: ss.number(),
 });
 export type ProviderConfig = ss.Infer<typeof ProviderConfig>;
 const ProviderConfigs = ss.array(ProviderConfig);
@@ -470,6 +471,7 @@ function parseEnv(env: Env): Config {
       }),
     });
   }
+  // Providers
   if (env.NEXT_PUBLIC_PROVIDER_V1_1) {
     providers.push({
       source: "provider",
@@ -477,6 +479,7 @@ function parseEnv(env: Env): Config {
       url: env.NEXT_PUBLIC_PROVIDER_V1_1,
       chainId: 1,
       address: getContractAddress({ chainId: 1, type: "Optimistic Oracle V1" }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V1_137) {
@@ -489,6 +492,7 @@ function parseEnv(env: Env): Config {
         chainId: 137,
         type: "Optimistic Oracle V1",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V1_288) {
@@ -501,6 +505,7 @@ function parseEnv(env: Env): Config {
         chainId: 288,
         type: "Optimistic Oracle V1",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V1_42161) {
@@ -513,6 +518,7 @@ function parseEnv(env: Env): Config {
         chainId: 42161,
         type: "Optimistic Oracle V1",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V1_5) {
@@ -522,6 +528,7 @@ function parseEnv(env: Env): Config {
       url: env.NEXT_PUBLIC_PROVIDER_V1_5,
       chainId: 5,
       address: getContractAddress({ chainId: 5, type: "Optimistic Oracle V1" }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V1_10) {
@@ -534,6 +541,7 @@ function parseEnv(env: Env): Config {
         chainId: 10,
         type: "Optimistic Oracle V1",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V2_1) {
@@ -543,6 +551,7 @@ function parseEnv(env: Env): Config {
       url: env.NEXT_PUBLIC_PROVIDER_V2_1,
       chainId: 1,
       address: getContractAddress({ chainId: 1, type: "Optimistic Oracle V2" }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V2_137) {
@@ -555,6 +564,7 @@ function parseEnv(env: Env): Config {
         chainId: 137,
         type: "Optimistic Oracle V2",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V2_288) {
@@ -567,6 +577,7 @@ function parseEnv(env: Env): Config {
         chainId: 288,
         type: "Optimistic Oracle V2",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V2_42161) {
@@ -579,6 +590,7 @@ function parseEnv(env: Env): Config {
         chainId: 42161,
         type: "Optimistic Oracle V2",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V2_5) {
@@ -588,6 +600,7 @@ function parseEnv(env: Env): Config {
       url: env.NEXT_PUBLIC_PROVIDER_V2_5,
       chainId: 5,
       address: getContractAddress({ chainId: 5, type: "Optimistic Oracle V2" }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V2_10) {
@@ -600,6 +613,7 @@ function parseEnv(env: Env): Config {
         chainId: 10,
         type: "Optimistic Oracle V2",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V3_1) {
@@ -609,6 +623,7 @@ function parseEnv(env: Env): Config {
       url: env.NEXT_PUBLIC_PROVIDER_V3_1,
       chainId: 1,
       address: getContractAddress({ chainId: 1, type: "Optimistic Oracle V3" }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V3_137) {
@@ -621,6 +636,7 @@ function parseEnv(env: Env): Config {
         chainId: 137,
         type: "Optimistic Oracle V3",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V3_288) {
@@ -633,6 +649,7 @@ function parseEnv(env: Env): Config {
         chainId: 288,
         type: "Optimistic Oracle V3",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V3_42161) {
@@ -645,6 +662,7 @@ function parseEnv(env: Env): Config {
         chainId: 42161,
         type: "Optimistic Oracle V3",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V3_5) {
@@ -654,6 +672,7 @@ function parseEnv(env: Env): Config {
       url: env.NEXT_PUBLIC_PROVIDER_V3_5,
       chainId: 5,
       address: getContractAddress({ chainId: 5, type: "Optimistic Oracle V3" }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_V3_10) {
@@ -666,6 +685,7 @@ function parseEnv(env: Env): Config {
         chainId: 10,
         type: "Optimistic Oracle V3",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_SKINNY_1) {
@@ -678,6 +698,7 @@ function parseEnv(env: Env): Config {
         chainId: 1,
         type: "Skinny Optimistic Oracle",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_SKINNY_137) {
@@ -690,6 +711,7 @@ function parseEnv(env: Env): Config {
         chainId: 137,
         type: "Skinny Optimistic Oracle",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_SKINNY_288) {
@@ -702,6 +724,7 @@ function parseEnv(env: Env): Config {
         chainId: 288,
         type: "Skinny Optimistic Oracle",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_SKINNY_42161) {
@@ -714,6 +737,7 @@ function parseEnv(env: Env): Config {
         chainId: 42161,
         type: "Skinny Optimistic Oracle",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_SKINNY_5) {
@@ -726,6 +750,7 @@ function parseEnv(env: Env): Config {
         chainId: 5,
         type: "Skinny Optimistic Oracle",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   if (env.NEXT_PUBLIC_PROVIDER_SKINNY_10) {
@@ -738,6 +763,7 @@ function parseEnv(env: Env): Config {
         chainId: 10,
         type: "Skinny Optimistic Oracle",
       }),
+      blockHistoryLimit: 100000,
     });
   }
   return {

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -172,9 +172,8 @@ export function oracleDataReducer(
 }
 export function OracleDataProvider({ children }: { children: ReactNode }) {
   const { addErrorMessage } = useErrorContext();
-  const oraclesService = oracles.Factory(
-    config.subgraphs.map((c) => ({ ...c, addErrorMessage }))
-  );
+  const oraclesServices = oracles.Factory(config.subgraphs);
+  const serviceConfigs = [...config.subgraphs, ...config.providers];
 
   const [queries, dispatch] = useReducer(
     oracleDataReducer,
@@ -186,7 +185,7 @@ export function OracleDataProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     // its important this client only gets initialized once
-    Client([oraclesService, ...oracleEthersServices], {
+    Client([...oraclesServices, ...oracleEthersServices], {
       requests: (requests) => dispatch({ type: "requests", data: requests }),
       assertions: (assertions) =>
         dispatch({ type: "assertions", data: assertions }),
@@ -194,9 +193,51 @@ export function OracleDataProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  errors.forEach((error, i) => {
-    if (error) console.warn("Oracle data error", i, errors);
-  });
+  useEffect(() => {
+    errors.forEach((error, i) => {
+      if (error == undefined) return;
+      // index of service must align with order configs are passed into client
+      const serviceConfig = serviceConfigs[i];
+      // this error is coming from ether provider queries, this would mean fallback is broken
+      if (serviceConfig?.source !== "gql") {
+        console.warn({ serviceConfig, error });
+        addErrorMessage({
+          text: "Currently unable to fetch all data, check back later",
+          link: {
+            text: "Use the Legacy Dapp instead",
+            href: "https://legacy.oracle.uma.xyz",
+          },
+        });
+        return;
+      }
+      const web3Fallback =
+        oracleEthersApis?.[serviceConfig.type]?.[serviceConfig.chainId];
+      if (web3Fallback && web3Fallback.queryLatestRequests) {
+        const web3Config = config.providers.find(
+          (c) =>
+            c.type == serviceConfig.type && c.chainId == serviceConfig.chainId
+        );
+        web3Fallback.queryLatestRequests(
+          web3Config?.blockHistoryLimit ?? 100000
+        );
+        // if we reach here, theres a subgraph thats not working, but we can still fetch limited  history through provider
+        addErrorMessage({
+          text: "The Graph is experiencing downtime, site may be slower than normal",
+        });
+      } else {
+        // if we reach here, we dont have a fallback for a specific subgraph, technically this shouldnt ever happen though
+        // if the app is configured correctly
+        console.warn({ serviceConfig, error });
+        addErrorMessage({
+          text: "Currently unable to fetch all data, check back later",
+          link: {
+            text: "Use the Legacy Dapp instead",
+            href: "https://legacy.oracle.uma.xyz",
+          },
+        });
+      }
+    });
+  }, [errors]);
 
   return (
     <OracleDataContext.Provider value={{ ...queries, errors }}>


### PR DESCRIPTION
## motivation
we had a critical time where our subgraph was down, but we also needed to dispute a proposal. we need a way to query providers as a backup in case the graph goes down.

## changes
this adds a feature to each ethers service to query based on a number of blocks ago. it will automatically be called if any of the graphs throw an error during querying. appropriate error messages will be displayed if this happens, alerting the user the site experience may be degraded. 

![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/592108d7-4977-458d-9c70-14856e12edf2)

## testing
this is difficult to test, you wil most likely need to checkout locally and edit your .env files to point to incorrect graph urls. this will trigger the fallback.

## todo
by default all lookback limits are set to 100000.  this may not be appropriate for all networks, if its a problem we can update these values per network and graph at a future point.