### PR TITLE
improve: logging and reduce gql query size

### DIFF
--- a/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
@@ -13,7 +13,7 @@ export async function getAssertions(url: string, chainId: ChainId) {
 async function fetchAllAssertions(url: string, queryName: string) {
   const result: OOV3GraphEntity[] = [];
   let skip = 0;
-  const first = 1000;
+  const first = 500;
   let assertions = await fetchAssertions(
     url,
     makeQuery(queryName, first, skip)

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -198,9 +198,9 @@ export function OracleDataProvider({ children }: { children: ReactNode }) {
       if (error == undefined) return;
       // index of service must align with order configs are passed into client
       const serviceConfig = serviceConfigs[i];
+      console.warn({ serviceConfig, error });
       // this error is coming from ether provider queries, this would mean fallback is broken
       if (serviceConfig?.source !== "gql") {
-        console.warn({ serviceConfig, error });
         addErrorMessage({
           text: "Currently unable to fetch all data, check back later",
           link: {
@@ -227,7 +227,6 @@ export function OracleDataProvider({ children }: { children: ReactNode }) {
       } else {
         // if we reach here, we dont have a fallback for a specific subgraph, technically this shouldnt ever happen though
         // if the app is configured correctly
-        console.warn({ serviceConfig, error });
         addErrorMessage({
           text: "Currently unable to fetch all data, check back later",
           link: {


### PR DESCRIPTION
## motivation
we are seeing gql error banners frequently since we implemented fallback system. this is because we want to know when we are using web3 fallbacks. currently we dont know why the banners are showing up so much

## changes
this adds more general logging for any errors that happen when querying data. this will only log to console. after some inspection it looks like its the polygon subgraph failing, which may be due to the size of the queries. we also reduce the size to see if that helps prevent failures to the subgraph
