### PR TITLE
improve: enrich rated assertions with data from their contract in ui

### DIFF
--- a/shared/constants/abi.ts
+++ b/shared/constants/abi.ts
@@ -14,41 +14,43 @@ export const proposePriceAbi = [
   },
 ];
 
-export const skinnyProposePriceAbi = [{
-  inputs: [
-    { internalType: "address", name: "requester", type: "address" },
-    { internalType: "bytes32", name: "identifier", type: "bytes32" },
-    { internalType: "uint32", name: "timestamp", type: "uint32" },
-    { internalType: "bytes", name: "ancillaryData", type: "bytes" },
-    {
-      components: [
-        { internalType: "address", name: "proposer", type: "address" },
-        { internalType: "address", name: "disputer", type: "address" },
-        {
-          internalType: "contract IERC20",
-          name: "currency",
-          type: "address",
-        },
-        { internalType: "bool", name: "settled", type: "bool" },
-        { internalType: "int256", name: "proposedPrice", type: "int256" },
-        { internalType: "int256", name: "resolvedPrice", type: "int256" },
-        { internalType: "uint256", name: "expirationTime", type: "uint256" },
-        { internalType: "uint256", name: "reward", type: "uint256" },
-        { internalType: "uint256", name: "finalFee", type: "uint256" },
-        { internalType: "uint256", name: "bond", type: "uint256" },
-        { internalType: "uint256", name: "customLiveness", type: "uint256" },
-      ],
-      internalType: "struct SkinnyOptimisticOracleInterface.Request",
-      name: "request",
-      type: "tuple",
-    },
-    { internalType: "int256", name: "proposedPrice", type: "int256" },
-  ],
-  name: "proposePrice",
-  outputs: [{ internalType: "uint256", name: "totalBond", type: "uint256" }],
-  stateMutability: "nonpayable",
-  type: "function",
-}];
+export const skinnyProposePriceAbi = [
+  {
+    inputs: [
+      { internalType: "address", name: "requester", type: "address" },
+      { internalType: "bytes32", name: "identifier", type: "bytes32" },
+      { internalType: "uint32", name: "timestamp", type: "uint32" },
+      { internalType: "bytes", name: "ancillaryData", type: "bytes" },
+      {
+        components: [
+          { internalType: "address", name: "proposer", type: "address" },
+          { internalType: "address", name: "disputer", type: "address" },
+          {
+            internalType: "contract IERC20",
+            name: "currency",
+            type: "address",
+          },
+          { internalType: "bool", name: "settled", type: "bool" },
+          { internalType: "int256", name: "proposedPrice", type: "int256" },
+          { internalType: "int256", name: "resolvedPrice", type: "int256" },
+          { internalType: "uint256", name: "expirationTime", type: "uint256" },
+          { internalType: "uint256", name: "reward", type: "uint256" },
+          { internalType: "uint256", name: "finalFee", type: "uint256" },
+          { internalType: "uint256", name: "bond", type: "uint256" },
+          { internalType: "uint256", name: "customLiveness", type: "uint256" },
+        ],
+        internalType: "struct SkinnyOptimisticOracleInterface.Request",
+        name: "request",
+        type: "tuple",
+      },
+      { internalType: "int256", name: "proposedPrice", type: "int256" },
+    ],
+    name: "proposePrice",
+    outputs: [{ internalType: "uint256", name: "totalBond", type: "uint256" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];
 
 export const disputePriceAbi = [
   {
@@ -195,3 +197,472 @@ export const ogAbi = [
     type: "function",
   },
 ];
+
+export const ratedAbi = [
+  {
+    inputs: [
+      { internalType: "uint256", name: "_bondAmount", type: "uint256" },
+      { internalType: "uint64", name: "_challengeWindow", type: "uint64" },
+      { internalType: "address", name: "_bondCurrency", type: "address" },
+      { internalType: "address", name: "_proposer", type: "address" },
+      { internalType: "address", name: "_oracle", type: "address" },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  { inputs: [], name: "amountCanNotBeZero", type: "error" },
+  { inputs: [], name: "canNotBeAddressZero", type: "error" },
+  { inputs: [], name: "invalidChallengeWindow", type: "error" },
+  { inputs: [], name: "proposerNotApproved", type: "error" },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "_newBondAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "contract IERC20",
+        name: "_newCurrency",
+        type: "address",
+      },
+    ],
+    name: "NewBondSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint64",
+        name: "_newChallengeWindow",
+        type: "uint64",
+      },
+    ],
+    name: "NewChallengeWindowSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint64",
+        name: "_timeToSettle",
+        type: "uint64",
+      },
+    ],
+    name: "NewTimeToSettleSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "previousOwner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "OwnershipTransferred",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "_proposerApproved",
+        type: "address",
+      },
+    ],
+    name: "ProposerApproved",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "_proposerRevoked",
+        type: "address",
+      },
+    ],
+    name: "ProposerRevoked",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "_reportID",
+        type: "uint256",
+      },
+    ],
+    name: "reportDiscarded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "_reportID",
+        type: "uint256",
+      },
+    ],
+    name: "reportDisputed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "_reportID",
+        type: "uint256",
+      },
+    ],
+    name: "reportMade",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "_reportID",
+        type: "uint256",
+      },
+    ],
+    name: "reportSettled",
+    type: "event",
+  },
+  {
+    inputs: [{ internalType: "address", name: "_address", type: "address" }],
+    name: "approveProposer",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "", type: "address" }],
+    name: "approvedProposer",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "bondAmount",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "bondCurrency",
+    outputs: [{ internalType: "contract IERC20", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "challengeWindow",
+    outputs: [{ internalType: "uint64", name: "", type: "uint64" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "_newBondAmount", type: "uint256" },
+      {
+        internalType: "contract IERC20",
+        name: "_newCurrency",
+        type: "address",
+      },
+    ],
+    name: "changeBondAmountAndCurrency",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    name: "disputedReportsID",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "_pubkey", type: "bytes" }],
+    name: "getPubkeyRoot",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_validatorIdentifier",
+        type: "bytes32",
+      },
+    ],
+    name: "getViolationsForValidator",
+    outputs: [
+      {
+        components: [
+          {
+            internalType: "bytes32",
+            name: "validatorIdentifier",
+            type: "bytes32",
+          },
+          { internalType: "uint32", name: "epochNumber", type: "uint32" },
+          { internalType: "uint32", name: "penaltyType", type: "uint32" },
+          {
+            internalType: "address",
+            name: "newFeeRecipientAddress",
+            type: "address",
+          },
+        ],
+        internalType: "struct RatedOracle.Violation[]",
+        name: "",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_reportID", type: "uint256" }],
+    name: "getViolationsInReport",
+    outputs: [
+      {
+        components: [
+          {
+            internalType: "bytes32",
+            name: "validatorIdentifier",
+            type: "bytes32",
+          },
+          { internalType: "uint32", name: "epochNumber", type: "uint32" },
+          { internalType: "uint32", name: "penaltyType", type: "uint32" },
+          {
+            internalType: "address",
+            name: "newFeeRecipientAddress",
+            type: "address",
+          },
+        ],
+        internalType: "struct RatedOracle.Violation[]",
+        name: "containedViolation",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_validatorIdentifier",
+        type: "bytes32",
+      },
+    ],
+    name: "isValidatorInDispute",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_validatorIdentifier",
+        type: "bytes32",
+      },
+    ],
+    name: "numberOfViolationsForValidator",
+    outputs: [{ internalType: "uint256", name: "len", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    name: "pendingReportsID",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint32", name: "_fromEpoch", type: "uint32" },
+      { internalType: "uint32", name: "_toEpoch", type: "uint32" },
+      {
+        components: [
+          {
+            internalType: "bytes32",
+            name: "validatorIdentifier",
+            type: "bytes32",
+          },
+          { internalType: "uint32", name: "epochNumber", type: "uint32" },
+          { internalType: "uint32", name: "penaltyType", type: "uint32" },
+          {
+            internalType: "address",
+            name: "newFeeRecipientAddress",
+            type: "address",
+          },
+        ],
+        internalType: "struct RatedOracle.Violation[]",
+        name: "_listViolations",
+        type: "tuple[]",
+      },
+    ],
+    name: "postReport",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "priceIdentifier",
+    outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint64", name: "_index", type: "uint64" }],
+    name: "removeDisputedReport",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "renounceOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "reportID",
+    outputs: [{ internalType: "uint256", name: "_value", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    name: "reports",
+    outputs: [
+      { internalType: "uint32", name: "fromEpoch", type: "uint32" },
+      { internalType: "uint32", name: "toEpoch", type: "uint32" },
+      { internalType: "uint256", name: "timestamp", type: "uint256" },
+      { internalType: "bytes32", name: "assertionID", type: "bytes32" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "_address", type: "address" }],
+    name: "revokeProposer",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint64", name: "_newChallengeWindow", type: "uint64" },
+    ],
+    name: "setChallengeWindow",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint64", name: "_timeToSettle", type: "uint64" }],
+    name: "setTimeToSettle",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "timeToSettle",
+    outputs: [{ internalType: "uint64", name: "", type: "uint64" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "address", name: "newOwner", type: "address" }],
+    name: "transferOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "", type: "uint256" },
+      { internalType: "bytes32", name: "", type: "bytes32" },
+    ],
+    name: "validatorInReport",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "bytes32", name: "", type: "bytes32" },
+      { internalType: "uint256", name: "", type: "uint256" },
+    ],
+    name: "violationsForValidator",
+    outputs: [
+      { internalType: "bytes32", name: "validatorIdentifier", type: "bytes32" },
+      { internalType: "uint32", name: "epochNumber", type: "uint32" },
+      { internalType: "uint32", name: "penaltyType", type: "uint32" },
+      {
+        internalType: "address",
+        name: "newFeeRecipientAddress",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "_token", type: "address" },
+      { internalType: "uint256", name: "_amount", type: "uint256" },
+      { internalType: "address", name: "_to", type: "address" },
+    ],
+    name: "withdrawFunds",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;

--- a/src/components/Panel/Details.tsx
+++ b/src/components/Panel/Details.tsx
@@ -29,6 +29,7 @@ export function Details({
   queryTextHex,
   moreInformation,
   project,
+  chainId,
 }: OracleQueryUI) {
   const isRated = project === "Rated";
 
@@ -86,7 +87,7 @@ export function Details({
           <SectionTitle>Additional Text Data</SectionTitle>
         </SectionTitleWrapper>
         {isRated && queryText ? (
-          <RatedAssertionTextData queryText={queryText} />
+          <RatedAssertionTextData queryText={queryText} chainId={chainId} />
         ) : (
           <AdditionalTextData
             description={description}

--- a/src/components/Panel/Details.tsx
+++ b/src/components/Panel/Details.tsx
@@ -6,6 +6,7 @@ import Timestamp from "public/assets/icons/timestamp.svg";
 import { Fragment } from "react";
 import styled from "styled-components";
 import { AdditionalTextData } from "./AdditionalTextData";
+import { RatedAssertionTextData } from "./RatedAssertionTextData";
 import {
   SectionSubTitle,
   SectionTitle,
@@ -27,7 +28,10 @@ export function Details({
   queryText,
   queryTextHex,
   moreInformation,
+  project,
 }: OracleQueryUI) {
+  const isRated = project === "Rated";
+
   return (
     <Wrapper>
       <DetailWrapper>
@@ -81,11 +85,15 @@ export function Details({
           <AncillaryDataIcon />
           <SectionTitle>Additional Text Data</SectionTitle>
         </SectionTitleWrapper>
-        <AdditionalTextData
-          description={description}
-          queryText={queryText}
-          queryTextHex={queryTextHex}
-        />
+        {isRated && queryText ? (
+          <RatedAssertionTextData queryText={queryText} />
+        ) : (
+          <AdditionalTextData
+            description={description}
+            queryText={queryText}
+            queryTextHex={queryTextHex}
+          />
+        )}
       </DetailWrapper>
       <DetailWrapper>
         <SectionTitleWrapper>

--- a/src/components/Panel/RatedAssertionTextData.tsx
+++ b/src/components/Panel/RatedAssertionTextData.tsx
@@ -1,0 +1,87 @@
+import { ratedAbi } from "@shared/constants/abi";
+import { BigNumber } from "ethers";
+import { useContractRead } from "wagmi";
+import { SectionSubTitle, Text } from "./style";
+
+type Props = {
+  queryText: string;
+};
+export function RatedAssertionTextData(props: Props) {
+  return (
+    <>
+      <SectionSubTitle>Report</SectionSubTitle>
+      <Report queryText={props.queryText} />
+      <SectionSubTitle>Violations</SectionSubTitle>
+      <Violations queryText={props.queryText} />
+    </>
+  );
+}
+
+export function Report(props: Props) {
+  const { data: report } = useContractRead({
+    abi: ratedAbi,
+    address: "0x1dd1ea5e2b3020f2564c8509b180ffc6fdf4fb8b",
+    functionName: "reports",
+    args: [BigNumber.from(props.queryText)],
+  });
+  if (!report) return null;
+  const { fromEpoch, toEpoch, timestamp, assertionID } = report;
+
+  return (
+    <div>
+      <Text>
+        <strong>From Epoch:</strong> {fromEpoch}
+      </Text>
+      <Text>
+        <strong>To Epoch:</strong> {toEpoch}
+      </Text>
+      <Text>
+        <strong>Timestamp:</strong> {timestamp.toString()}
+      </Text>
+      <Text>
+        <strong>Assertion ID:</strong> {assertionID}
+      </Text>
+    </div>
+  );
+}
+
+export function Violations(props: Props) {
+  const { data: violations } = useContractRead({
+    abi: ratedAbi,
+    address: "0x1dd1ea5e2b3020f2564c8509b180ffc6fdf4fb8b",
+    functionName: "getViolationsInReport",
+    args: [BigNumber.from(props.queryText)],
+  });
+  if (!violations) return null;
+
+  if (violations.length === 0) {
+    return (
+      <div>
+        <Text>This report contains no violations</Text>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {violations.map((violation, i) => (
+        <div key={i}>
+          <Text>
+            <strong>Validator identifier:</strong>{" "}
+            {violation.validatorIdentifier}
+          </Text>
+          <Text>
+            <strong>Epoch:</strong> {violation.epochNumber}
+          </Text>
+          <Text>
+            <strong>Penalty type:</strong> {violation.penaltyType}
+          </Text>
+          <Text>
+            <strong>New fee recipient address:</strong>{" "}
+            {violation.newFeeRecipientAddress}
+          </Text>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Panel/RatedAssertionTextData.tsx
+++ b/src/components/Panel/RatedAssertionTextData.tsx
@@ -1,18 +1,23 @@
 import { ratedAbi } from "@shared/constants/abi";
+import type { ChainId } from "@shared/types";
 import { BigNumber } from "ethers";
 import { useContractRead } from "wagmi";
 import { SectionSubTitle, Text } from "./style";
 
+const mainnetAddress = "0x51881A1Cde5DBAE15D02aE1824940b19768d8F2b";
+const goerliAddress = "0x1dd1ea5e2b3020f2564c8509b180ffc6fdf4fb8b";
+
 type Props = {
   queryText: string;
+  chainId: ChainId;
 };
 export function RatedAssertionTextData(props: Props) {
   return (
     <>
       <SectionSubTitle>Report</SectionSubTitle>
-      <Report queryText={props.queryText} />
+      <Report {...props} />
       <SectionSubTitle>Violations</SectionSubTitle>
-      <Violations queryText={props.queryText} />
+      <Violations {...props} />
     </>
   );
 }
@@ -20,7 +25,7 @@ export function RatedAssertionTextData(props: Props) {
 export function Report(props: Props) {
   const { data: report } = useContractRead({
     abi: ratedAbi,
-    address: "0x1dd1ea5e2b3020f2564c8509b180ffc6fdf4fb8b",
+    address: props.chainId === 1 ? mainnetAddress : goerliAddress,
     functionName: "reports",
     args: [BigNumber.from(props.queryText)],
   });
@@ -48,7 +53,7 @@ export function Report(props: Props) {
 export function Violations(props: Props) {
   const { data: violations } = useContractRead({
     abi: ratedAbi,
-    address: "0x1dd1ea5e2b3020f2564c8509b180ffc6fdf4fb8b",
+    address: props.chainId === 1 ? mainnetAddress : goerliAddress,
     functionName: "getViolationsInReport",
     args: [BigNumber.from(props.queryText)],
   });


### PR DESCRIPTION
We should show the report data as acquired from the rated oracle contract in the panel.

* fetch the report and violations from the contract
* show this instead of the additional text data for these requests

Testing:

I can't seem to find the goerli transaction that they used as an example in the oracle ui. hardcoded that value ("5") just to see that everything is fetched and displayed correctly, and I can confirm that it is.