### PR TITLE
improve: add report number to rated assertions

### DIFF
--- a/src/components/Panel/RatedAssertionTextData.tsx
+++ b/src/components/Panel/RatedAssertionTextData.tsx
@@ -14,7 +14,7 @@ type Props = {
 export function RatedAssertionTextData(props: Props) {
   return (
     <>
-      <SectionSubTitle>Report</SectionSubTitle>
+      <SectionSubTitle>Report #{props.queryText}</SectionSubTitle>
       <Report {...props} />
       <SectionSubTitle>Violations</SectionSubTitle>
       <Violations {...props} />


### PR DESCRIPTION
I accidentally took out the report number. Add it back in.