### PR TITLE
fix: dropdown z index

### DIFF
--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -42,7 +42,7 @@ export function Notifications() {
 const AnimatedNotification = animated(Notification);
 
 const Wrapper = styled.div`
-  z-index: 2;
+  z-index: 9999;
   position: fixed;
   top: 0;
   left: 0;

--- a/src/components/RadioDropdown.tsx
+++ b/src/components/RadioDropdown.tsx
@@ -57,7 +57,6 @@ const _Trigger = styled(DropdownTrigger)`
 
 const _Content = styled(DropdownContent)`
   padding-block: 0;
-  z-index: 2;
 `;
 
 const _RadioItem = styled(RadioItem)`

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -71,7 +71,7 @@ const slideLeftAndFade = keyframes`
 `;
 
 const Content = styled(RadixTooltip.Content)`
-  z-index: 2;
+  z-index: 9999;
   max-width: 400px;
   overflow-wrap: break-word;
   padding: 20px;

--- a/src/components/style.tsx
+++ b/src/components/style.tsx
@@ -48,6 +48,7 @@ export const DropdownContent = styled(RadixDropdown.Content)`
   background: var(--white);
   border: 1px solid var(--blue-grey-400);
   border-radius: 4px;
+  z-index: 9999;
 `;
 
 export const CheckboxBox = styled.div<{ $checked: CheckboxState }>`

--- a/src/stories/Panel.stories.tsx
+++ b/src/stories/Panel.stories.tsx
@@ -89,6 +89,33 @@ export const Propose: Story = {
     page: "propose",
     query: makeMockOracleQueryUI({
       actionType: "propose",
+      proposeOptions: [
+        {
+          label: "No",
+          value: "0",
+          secondaryLabel: "p1",
+        },
+        {
+          label: "Yes",
+          value: "1",
+          secondaryLabel: "p2",
+        },
+        {
+          label: "unknown/50-50",
+          value: "0.5",
+          secondaryLabel: "p3",
+        },
+        {
+          label: "Early request",
+          value:
+            "-57896044618658097711785492504343953926634992332820282019728.792003956564819968",
+          secondaryLabel: "p4",
+        },
+        {
+          label: "Custom",
+          value: "custom",
+        },
+      ],
     }),
   },
 };


### PR DESCRIPTION
When I converted the panel to tailwind, I overlooked an implementation detail: for reasons I'm not so sure about, [tailwind specifies z indexes in multiples of 10](https://tailwindcss.com/docs/z-index#setting-the-z-index).

In the rest of the app, we count z index in increments of 1. I had the panel set to z index of 1, and the dropdown to a z index of 2.

This meant that when I changed the panel to tailwind and gave it tailwind's equivalent of z  index 1, which is actually z index 10, it broke the implementation by making it a higher z index than that of the dropdown and caused the dropdown to be hidden behind the panel.

I missed this because I did not have a storybook example with the dropdown input for the propose state, which has now been rectified.

I have updated all the other z indexes used in the app to the max value, since each of those items is not intended to be used above one another, and also they are always expected to appear on top of everything else: the tooltips and the notifications.

Going forward these issues will be avoided entirely in future implementations — we now have the native [html dialog element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) for this, and it puts the items in a special "top" layer that is always above everything else regardless of z index.