### PR TITLE
fix: add break words to p tags

### DIFF
--- a/src/components/Panel/AdditionalTextData.tsx
+++ b/src/components/Panel/AdditionalTextData.tsx
@@ -31,6 +31,7 @@ export function AdditionalTextData({
           <div className="text-xs sm:text-base">
             <ReactMarkdown
               components={{
+                p: (props) => <p {...props} className="break-words" />,
                 a: (props) => (
                   <a
                     className="text-red-500 hover:underline"

--- a/src/components/Panel/style.tsx
+++ b/src/components/Panel/style.tsx
@@ -2,7 +2,7 @@ import NextLink from "next/link";
 import type { ComponentPropsWithoutRef } from "react";
 
 export const Text = ({ children }: { children: React.ReactNode }) => (
-  <p className="text-xs sm:text-base">{children}</p>
+  <p className="text-xs sm:text-base break-words">{children}</p>
 );
 
 export const Link = (props: ComponentPropsWithoutRef<typeof NextLink>) => (


### PR DESCRIPTION
Add the `break-words` property to the description <p> tags so that they are allowed to break long text like addresses and hashes.