### PR TITLE
fix: allow dropdowns to end parsing with , or .

### DIFF
--- a/src/helpers/queryParsing.ts
+++ b/src/helpers/queryParsing.ts
@@ -184,7 +184,7 @@ function dynamicPolymarketOptions(
     /res_data: (p\d): (\d+\.\d+|\d+), (p\d): (\d+\.\d+|\d+), (p\d): (\d+\.\d+|\d+)/,
   );
   const correspondence = decodedAncillaryData.match(
-    /Where (p\d) corresponds to ([^,]+), (p\d) to ([^,]+), (p\d) to ([^,]+)/,
+    /Where (p\d) corresponds to ([^,]+), (p\d) to ([^,]+), (p\d) to ([^.,]+)/,
   );
 
   if (!resData || !correspondence) return [];


### PR DESCRIPTION
## motivation
polymarket updated ancillary data which slightly affects dropdown parsing. preivously all data would end with a comma, now its possible they end with a period. small change but this breaks drop down option parsing.

## changes
this alters the regex to end on a comma or period, to make sure it fixes future requests and still works with past requests

![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/c5eb03f7-5abc-4c6d-92d2-f0c08db05e65)

and older request
![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/066b6274-1f78-4ec4-a4e7-24778d7a680b)
