### PR TITLE
fix: dont show disputed when settle is available

### DIFF
--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -340,7 +340,7 @@ export function useDisputeAction({
 }: {
   query?: OracleQueryUI;
 }): ActionState | undefined {
-  const { disputePriceParams, chainId } = query ?? {};
+  const { disputePriceParams, chainId, actionType } = query ?? {};
   const {
     config: disputePriceConfig,
     error: prepareDisputePriceError,
@@ -387,6 +387,7 @@ export function useDisputeAction({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [disputePriceTransaction]);
 
+  if (actionType === "settle") return undefined;
   if (disputePriceParams === undefined) return undefined;
 
   if (isPrepareDisputePriceLoading) {


### PR DESCRIPTION
## motivation
theres a bunch of expired proposals that cant be settled on testnet for example: https://testnet.oracle.umaproject.org/?chain=5&transactionHash=0x95970c9252a4e1254aba892c81556d613b39e7c8fa92b365d00a69e20a226f5f&eventIndex=10

## changes
we were not correctly gaurding the dispute function when action type was set to "settle".  this exits so settle code can correctly take over