### PR TITLE
fix: show yes no dropdown for yes no query

### DIFF
--- a/src/helpers/queryParsing.ts
+++ b/src/helpers/queryParsing.ts
@@ -16,6 +16,10 @@ export function isOptimisticGovernor(decodedAncillaryData: string) {
   );
 }
 
+export function isYesOrNo(decodedIdentifier: string) {
+  return decodedIdentifier === "YES_OR_NO_QUERY";
+}
+
 export function checkIfIsCozy(decodedAncillaryData: string) {
   const cozyToken = "This will revert if a non-YES answer is proposed.";
   if (decodedAncillaryData.includes(cozyToken)) {
@@ -118,7 +122,9 @@ export function getQueryMetaData(
       description,
       umipUrl,
       umipNumber,
-      proposeOptions: undefined,
+      proposeOptions: isYesOrNo(decodedIdentifier)
+        ? makeSimpleYesOrNoOptions()
+        : undefined,
       project,
     };
   }


### PR DESCRIPTION
## motivation
there are some yes no query identifiers not showing the right  option selections in details page

## changes
this adds a simple yes/ no dropdown if it detects a yes no identifier