### PR TITLE
feat: get block explorer label for each chain

### DIFF
--- a/shared/utils/ethers.ts
+++ b/shared/utils/ethers.ts
@@ -149,6 +149,8 @@ export function getBlockExplorerNameForChain(chainId: ChainId) {
       return "Snowtrace";
     case 42161:
       return "Arbiscan";
+    default:
+      "Block Explorer";
   }
 }
 

--- a/shared/utils/ethers.ts
+++ b/shared/utils/ethers.ts
@@ -129,6 +129,29 @@ function getBlockExplorerUrlForChain(chainId: ChainId) {
   }
 }
 
+export function getBlockExplorerNameForChain(chainId: ChainId) {
+  switch (chainId) {
+    case 0:
+      return;
+    case 1 || 5:
+      return "Etherscan";
+    case 10:
+      return "Etherscan";
+    case 100:
+      return "Gnosisscan";
+    case 137 || 80001:
+      return "Polygonscan";
+    case 288:
+      return "Bobascan";
+    case 416:
+      return "SX Explorer";
+    case 43114:
+      return "Snowtrace";
+    case 42161:
+      return "Arbiscan";
+  }
+}
+
 export function makeBlockExplorerLink(
   hash: string,
   chainId: ChainId,

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -3,7 +3,10 @@
 import { LoadingSpinner } from "@/components";
 import { mobile, smallMobile, tablet } from "@/constants";
 import type { Notification, UniqueId } from "@/types";
-import { makeBlockExplorerLink } from "@shared/utils";
+import {
+  getBlockExplorerNameForChain,
+  makeBlockExplorerLink,
+} from "@shared/utils";
 import NextLink from "next/link";
 import Close from "public/assets/icons/close.svg";
 import Failure from "public/assets/icons/failure.svg";
@@ -82,7 +85,7 @@ export function Notification({
             href={makeBlockExplorerLink(transactionHash, chainId, "tx")}
             target="_blank"
           >
-            View on Etherscan
+            View on {getBlockExplorerNameForChain(chainId)}
           </Link>
         )}
       </TextWrapper>


### PR DESCRIPTION
closes #UMA-1933

## Motivation

If a transaction happens on chain X, we want to have a label that says "View on `<BLOCK_EXPLORER_FOR_CHAIN>`"