### PR TITLE
fix: allow more than 5k gql queries for oov1/2

### DIFF
--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
@@ -29,7 +29,9 @@ async function fetchAllRequests(url: string, queryName: string, isV2: boolean) {
     url,
     makeQuery(queryName, isV2, first, skip)
   );
-  while (requests.length > 0) {
+
+  // thegraph wont allow skip > 5000,
+  while (requests.length > 0 && skip < 5000) {
     result.push(...requests);
     skip += first;
     requests = await fetchPriceRequests(
@@ -37,7 +39,21 @@ async function fetchAllRequests(url: string, queryName: string, isV2: boolean) {
       makeQuery(queryName, isV2, first, skip)
     );
   }
+  
+  // have to use time based logic after we run out of skip size
+  while (requests.length === first) {
+    result.push(...requests);
+    const lastTime = requests[requests.length-1].time;
+    requests = await fetchPriceRequests(
+      url,
+      makeTimeBasedQuery(queryName,isV2,first,Number(lastTime))
+    )
+  }
+
+  result.push(...requests);
+
   return result;
+  
 }
 
 async function fetchPriceRequests(url: string, query: string) {
@@ -59,6 +75,63 @@ function makeQuery(
   const query = gql`
   query ${queryName} {
     optimisticPriceRequests(orderBy: time, orderDirection: desc, first: ${first}, skip: ${skip}) {
+      id
+      identifier
+      ancillaryData
+      time
+      requester
+      currency
+      reward
+      finalFee
+      proposer
+      proposedPrice
+      proposalExpirationTimestamp
+      disputer
+      settlementPrice
+      settlementPayout
+      settlementRecipient
+      state
+      requestTimestamp
+      requestBlockNumber
+      requestHash
+      requestLogIndex
+      proposalTimestamp
+      proposalBlockNumber
+      proposalHash
+      proposalLogIndex
+      disputeTimestamp
+      disputeBlockNumber
+      disputeHash
+      disputeLogIndex
+      settlementTimestamp
+      settlementBlockNumber
+      settlementHash
+      settlementLogIndex
+      ${
+        isV2
+          ? `
+            customLiveness
+            bond
+            eventBased
+            `
+          : ""
+      }
+    }
+  }
+`;
+
+  return query;
+}
+
+function makeTimeBasedQuery(
+  queryName: string,
+  isV2: boolean,
+  first: number,
+  lastTime: number,
+) {
+  const query = gql`
+  query ${queryName} {
+    optimisticPriceRequests(orderBy: time, orderDirection: desc, first: ${first}, where: { time_lt: ${lastTime}}) {
       id
       identifier
       ancillaryData

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -200,7 +200,7 @@ export function OracleDataProvider({ children }: { children: ReactNode }) {
       if (error == undefined) return;
       // index of service must align with order configs are passed into client
       const serviceConfig = serviceConfigs[i];
-      console.warn({ serviceConfig, error });
+      console.warn({ serviceConfig, error, i });
       // this error is coming from ether provider queries, this would mean fallback is broken
       if (serviceConfig?.source !== "gql") {
         addErrorMessage({


### PR DESCRIPTION
## motivation
![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/2437d3d1-2f36-4fbc-80af-ba93329ef9a4)
apprently the graph does not let us skip more than 5k items, which we now have more than

## changes
uses recommended query "where" on object property time, which seems to do the trick for everything after 5k
