### PR TITLE
fix: show something is not settleable

### DIFF
--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -573,9 +573,9 @@ export function useSettlePriceAction({
   // this means this is probably disputed, but no answer available from dvm yet
   if (prepareSettlePriceError) {
     return {
-      title: disputed,
+      title: "Unable to Settle",
       disabled: true,
-      disabledReason: "This query is disputed.",
+      disabledReason: prepareSettlePriceError.message,
     };
   }
   if (isSuccess) {


### PR DESCRIPTION
## motivation
Theres a bunch of lingering queries in the verify page.  we want to get rid of them, first step is understanding that these cant be settled:
previously:
![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/bbb0beaa-07c8-4650-b10e-d0575a353607)

after change:
![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/c818bc66-6ffd-4409-855a-7b72ebdffa09)
