### PR TITLE
fix: add skinny query params to allow settle

### DIFF
--- a/libs/src/clients/erc20/client.e2e.ts
+++ b/libs/src/clients/erc20/client.e2e.ts
@@ -13,7 +13,7 @@ describe("erc20", function () {
   let events: Event[];
   test("inits", function () {
     const provider = ethers.providers.getDefaultProvider(
-      process.env.CUSTOM_NODE_URL
+      process.env.CUSTOM_NODE_URL,
     );
     client = Client.connect(address, provider);
     assert.ok(client);

--- a/libs/src/clients/erc20/client.ts
+++ b/libs/src/clients/erc20/client.ts
@@ -64,7 +64,7 @@ export function reduceEvents(state: EventState = {}, event: Event): EventState {
 
 export function getEventState(
   events: Event[],
-  initialState: EventState = {}
+  initialState: EventState = {},
 ): EventState {
   return events.reduce(reduceEvents, initialState);
 }

--- a/libs/src/clients/optimisticOracle/client.e2e.ts
+++ b/libs/src/clients/optimisticOracle/client.e2e.ts
@@ -11,7 +11,7 @@ describe("OptimisticOracle", function () {
   let client: Client.Instance;
   test("inits", function () {
     const provider = ethers.providers.getDefaultProvider(
-      process.env.CUSTOM_NODE_URL
+      process.env.CUSTOM_NODE_URL,
     );
     client = Client.connect(address, provider);
     assert.ok(client);

--- a/libs/src/clients/optimisticOracle/client.ts
+++ b/libs/src/clients/optimisticOracle/client.ts
@@ -16,7 +16,7 @@ export function connect(address: string, provider: SignerOrProvider): Instance {
 }
 
 export const contractInterface = new utils.Interface(
-  getOptimisticOracleInterfaceAbi()
+  getOptimisticOracleInterfaceAbi(),
 );
 
 export type RequestPrice = GetEventType<Instance, "RequestPrice">;
@@ -79,7 +79,7 @@ export interface EventState {
 }
 
 export function requestId(
-  request: Omit<RequestKey, "timestamp"> & { timestamp: BigNumberish }
+  request: Omit<RequestKey, "timestamp"> & { timestamp: BigNumberish },
 ): string {
   // this matches how we generate ids in the subgraph
   return [
@@ -225,7 +225,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
 }
 export function getEventState(
   events: Event[],
-  eventState: EventState = {}
+  eventState: EventState = {},
 ): EventState {
   return events.reduce(reduceEvents, eventState);
 }

--- a/libs/src/clients/optimisticOracleV2/client.e2e.ts
+++ b/libs/src/clients/optimisticOracleV2/client.e2e.ts
@@ -17,7 +17,7 @@ describe("OptimisticOracleV2", function () {
   let client: Client.Instance;
   test("inits", function () {
     const provider = ethers.providers.getDefaultProvider(
-      process.env.PROVIDER_URL_137
+      process.env.PROVIDER_URL_137,
     );
     client = Client.connect(address, provider);
     assert.ok(client);
@@ -32,7 +32,7 @@ describe("OptimisticOracleV2", function () {
       requester,
       identifier,
       timestamp,
-      ancillaryData
+      ancillaryData,
     );
     assert.ok(request);
   });

--- a/libs/src/clients/optimisticOracleV2/client.ts
+++ b/libs/src/clients/optimisticOracleV2/client.ts
@@ -16,7 +16,7 @@ export function connect(address: string, provider: SignerOrProvider): Instance {
 }
 
 export const contractInterface = new utils.Interface(
-  getOptimisticOracleV2InterfaceAbi()
+  getOptimisticOracleV2InterfaceAbi(),
 );
 
 export type RequestPrice = GetEventType<Instance, "RequestPrice">;
@@ -87,7 +87,7 @@ export interface EventState {
 }
 
 export function requestId(
-  request: Omit<RequestKey, "timestamp"> & { timestamp: BigNumberish }
+  request: Omit<RequestKey, "timestamp"> & { timestamp: BigNumberish },
 ): string {
   // if enabling sorting, put timestamp first
   return [
@@ -233,7 +233,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
 }
 export function getEventState(
   events: Event[],
-  eventState: EventState = {}
+  eventState: EventState = {},
 ): EventState {
   return events.reduce(reduceEvents, eventState);
 }

--- a/libs/src/clients/optimisticOracleV3/client.ts
+++ b/libs/src/clients/optimisticOracleV3/client.ts
@@ -19,7 +19,7 @@ export function connect(address: string, provider: SignerOrProvider): Instance {
 }
 
 export const contractInterface = new utils.Interface(
-  getOptimisticOracleV3InterfaceAbi()
+  getOptimisticOracleV3InterfaceAbi(),
 );
 
 export type AssertionMade = GetEventType<Instance, "AssertionMade">;
@@ -75,7 +75,7 @@ export interface EventState {
 
 export function reduceEvents(
   state: EventState,
-  event: SerializableEvent
+  event: SerializableEvent,
 ): EventState {
   switch (event.event) {
     case "AssertionMade": {
@@ -164,7 +164,7 @@ export function reduceEvents(
 }
 export function getEventState(
   events: SerializableEvent[],
-  eventState: EventState = {}
+  eventState: EventState = {},
 ): EventState {
   return events.reduce(reduceEvents, eventState);
 }

--- a/libs/src/clients/skinnyOptimisticOracle/client.e2e.ts
+++ b/libs/src/clients/skinnyOptimisticOracle/client.e2e.ts
@@ -11,7 +11,7 @@ describe("SkinnyOptimisticOracle", function () {
   let client: Client.Instance;
   test("inits", function () {
     const provider = ethers.providers.getDefaultProvider(
-      process.env.CUSTOM_NODE_URL
+      process.env.CUSTOM_NODE_URL,
     );
     client = Client.connect(address, provider);
     assert.ok(client);

--- a/libs/src/clients/skinnyOptimisticOracle/client.ts
+++ b/libs/src/clients/skinnyOptimisticOracle/client.ts
@@ -15,7 +15,7 @@ export function connect(address: string, provider: SignerOrProvider): Instance {
 }
 
 export const contractInterface = new utils.Interface(
-  getSkinnyOptimisticOracleAbi()
+  getSkinnyOptimisticOracleAbi(),
 );
 
 export type RequestPrice = GetEventType<Instance, "RequestPrice">;
@@ -80,7 +80,7 @@ export interface EventState {
 }
 
 export function requestId(
-  request: Omit<RequestKey, "timestamp"> & { timestamp: BigNumberish }
+  request: Omit<RequestKey, "timestamp"> & { timestamp: BigNumberish },
 ): string {
   // if enabling sorting, put timestamp first
   return [
@@ -91,6 +91,7 @@ export function requestId(
   ].join("!");
 }
 export function reduceEvents(state: EventState, event: Event): EventState {
+  console.log("skinny events", event.args);
   switch (event.event) {
     case "RequestPrice": {
       const typedEvent = event as RequestPrice;
@@ -178,7 +179,7 @@ export function reduceEvents(state: EventState, event: Event): EventState {
 }
 export function getEventState(
   events: Event[],
-  eventState: EventState = {}
+  eventState: EventState = {},
 ): EventState {
   return events.reduce(reduceEvents, eventState);
 }

--- a/libs/src/constants.ts
+++ b/libs/src/constants.ts
@@ -177,11 +177,11 @@ export function getContractInfo(params: {
   type: string;
 }): ContractInfo {
   const found = ContractInfoList.find(
-    ({ chainId, type }) => chainId === params.chainId && type === params.type
+    ({ chainId, type }) => chainId === params.chainId && type === params.type,
   );
   if (!found)
     throw new Error(
-      `Unable to find contract info for ${params.type} on chain ${params.chainId}`
+      `Unable to find contract info for ${params.type} on chain ${params.chainId}`,
     );
   return found;
 }

--- a/libs/src/multicall.ts
+++ b/libs/src/multicall.ts
@@ -48,7 +48,7 @@ export class Multicall<MulticallType extends multicall.Instance>
       target: contractInstance.address,
       callData: contractInstance.interface.encodeFunctionData(
         call.method,
-        call.args
+        call.args,
       ),
     };
   }
@@ -58,7 +58,7 @@ export class Multicall<MulticallType extends multicall.Instance>
     const { contractInstance, call } = request;
     return contractInstance.interface.decodeFunctionResult(
       call.method,
-      response
+      response,
     );
   }
 
@@ -80,10 +80,10 @@ export class Multicall<MulticallType extends multicall.Instance>
   // reads from the contract, returns the read results in order that requests were queued.
   public async read(_requests: Request[] = this.requests) {
     const encodedRequests = _requests.map((request) =>
-      this.encodeRequest(request)
+      this.encodeRequest(request),
     );
     const { returnData } = await this.multicallClient.callStatic.aggregate(
-      encodedRequests
+      encodedRequests,
     );
     const zipped = zip(_requests, returnData);
     return zipped.map(([request, response]) => {

--- a/libs/src/multicall2.ts
+++ b/libs/src/multicall2.ts
@@ -13,12 +13,12 @@ class Multicall2 extends Multicall<multicall2.Instance> {
   // reads from the contract, returns the read and error results in order that requests were queued.
   public async readWithErrors(_requests: Request[] = this.requests) {
     const encodedRequests = _requests.map((request) =>
-      this.encodeRequest(request)
+      this.encodeRequest(request),
     );
     const [, , returnData] =
       await this.multicallClient.callStatic.tryBlockAndAggregate(
         false,
-        encodedRequests
+        encodedRequests,
       );
     const zipped = zip(_requests, returnData);
     return zipped.map(([request, response]) => {

--- a/libs/src/oracle-sdk-v1/client.ts
+++ b/libs/src/oracle-sdk-v1/client.ts
@@ -19,7 +19,7 @@ export class Client {
     public readonly store: Store,
     public readonly update: Update,
     public readonly sm: StateMachine,
-    public readonly poller: StateMachine
+    public readonly poller: StateMachine,
   ) {}
   setUser(params: Partial<User>): string {
     const address = params.address && ethers.utils.getAddress(params.address);
@@ -46,7 +46,7 @@ export class Client {
     return result;
   }
   setActiveRequestByTransaction(
-    params: setActiveRequestByTransaction.Params
+    params: setActiveRequestByTransaction.Params,
   ): string {
     const result = this.sm.types.setActiveRequestByTransaction.create(params);
     this.sm.types.updateActiveRequest.create(undefined);
@@ -73,7 +73,7 @@ export class Client {
         confirmations: 1,
         checkTxIntervalSec,
       },
-      user.address
+      user.address,
     );
   }
   proposePrice(proposedPriceDecimals: string | number): string {
@@ -96,7 +96,7 @@ export class Client {
         confirmations: 1,
         checkTxIntervalSec,
       },
-      user.address
+      user.address,
     );
   }
   disputePrice(): string {
@@ -117,7 +117,7 @@ export class Client {
         currency: request.currency,
         checkTxIntervalSec,
       },
-      user.address
+      user.address,
     );
   }
   settle(): string {
@@ -138,7 +138,7 @@ export class Client {
         currency: request.currency,
         checkTxIntervalSec,
       },
-      user.address
+      user.address,
     );
   }
   switchOrAddChain(): string {
@@ -149,14 +149,14 @@ export class Client {
     assert(inputRequest.chainId, "requires active request chainId");
     return this.sm.types.switchOrAddChain.create(
       { chainId: inputRequest.chainId, provider: user.provider },
-      user.address
+      user.address,
     );
   }
   // runs statemachine step loop pretty fast by default.
   startInterval(delayMs = 1): void {
     assert(
       !this.intervalStarted,
-      "Interval already started, try stopping first"
+      "Interval already started, try stopping first",
     );
     this.intervalStarted = true;
     loop(async () => {
@@ -195,7 +195,7 @@ export function factory(
   config: state.Config,
   emit: Emit,
   OptimisticOracle: NewOracle,
-  sortedRequests: SortedRequests
+  sortedRequests: SortedRequests,
 ): Client {
   const store = new Store(emit);
   store.write((write) => {
@@ -216,8 +216,8 @@ export function factory(
           new OptimisticOracle(
             provider,
             chain.optimisticOracleAddress,
-            chain.chainId
-          )
+            chain.chainId,
+          ),
         );
     }
   });
@@ -236,12 +236,12 @@ export function factory(
         startBlock: chainConfig.earliestBlockNumber,
         maxRange: chainConfig.maxEventRangeQuery,
       },
-      "poller"
+      "poller",
     );
     // long running poller which only looks for new events
     poller.types.pollNewEvents.create(
       { chainId: Number(chainId), pollRateSec: chainConfig.checkTxIntervalSec },
-      "poller"
+      "poller",
     );
   }
   // create active request poller for all chains. Should only have one of these

--- a/libs/src/oracle-sdk-v1/errors.ts
+++ b/libs/src/oracle-sdk-v1/errors.ts
@@ -13,7 +13,7 @@ export class ExistenceError extends Error {
 // Special assert which checks for existence and throw existence error
 export function assertExists<T>(
   condition: T,
-  message = ""
+  message = "",
 ): asserts condition is NonNullable<T> {
   if (!exists(condition)) throw new ExistenceError(message);
 }
@@ -30,7 +30,7 @@ export function ignoreExistenceError<X>(call: () => X): X | undefined {
 
 // same function but for async calls
 export async function ignoreExistenceErrorAsync<X>(
-  call: () => X | Promise<X>
+  call: () => X | Promise<X>,
 ): Promise<X | undefined> {
   try {
     return await call();

--- a/libs/src/oracle-sdk-v1/factory.ts
+++ b/libs/src/oracle-sdk-v1/factory.ts
@@ -11,7 +11,7 @@ import OptimisticV2Factory from "./optimisticV2Factory";
 export type PublicEmit = (
   oracleType: OracleType,
   state: State,
-  prev: State
+  prev: State,
 ) => void;
 const EventHandler =
   (oracleType: OracleType, publicEmit: PublicEmit): Emit =>
@@ -20,7 +20,7 @@ const EventHandler =
 
 const Factory = (
   configTable: PartialConfigTable,
-  emit: PublicEmit
+  emit: PublicEmit,
 ): ClientTable => {
   const sortedRequests = new SortedRequests();
   return Object.fromEntries(
@@ -33,7 +33,7 @@ const Factory = (
             OptimisticFactory(
               config,
               EventHandler(oracleType, emit),
-              sortedRequests
+              sortedRequests,
             ),
           ];
         case OracleType.Skinny:
@@ -42,7 +42,7 @@ const Factory = (
             SkinnyFactory(
               config,
               EventHandler(oracleType, emit),
-              sortedRequests
+              sortedRequests,
             ),
           ];
         case OracleType.OptimisticV2:
@@ -51,13 +51,13 @@ const Factory = (
             OptimisticV2Factory(
               config,
               EventHandler(oracleType, emit),
-              sortedRequests
+              sortedRequests,
             ),
           ];
         default:
           throw new Error(`Unknown oracle type: ${oracleType}`);
       }
-    })
+    }),
   );
 };
 

--- a/libs/src/oracle-sdk-v1/optimisticFactory.ts
+++ b/libs/src/oracle-sdk-v1/optimisticFactory.ts
@@ -9,7 +9,7 @@ import type { Emit } from "./store";
 const Factory = (
   config: state.PartialConfig,
   emit: Emit,
-  sortedRequests: SortedRequests = new SortedRequests()
+  sortedRequests: SortedRequests = new SortedRequests(),
 ): Client => {
   const fullConfig = DefaultConfig({
     getMulticall2Address,

--- a/libs/src/oracle-sdk-v1/optimisticV2Factory.ts
+++ b/libs/src/oracle-sdk-v1/optimisticV2Factory.ts
@@ -9,7 +9,7 @@ import type { Emit } from "./store";
 const Factory = (
   config: state.PartialConfig,
   emit: Emit,
-  sortedRequests: SortedRequests = new SortedRequests()
+  sortedRequests: SortedRequests = new SortedRequests(),
 ): Client => {
   const fullConfig = DefaultConfig({
     getMulticall2Address,

--- a/libs/src/oracle-sdk-v1/services/erc20.ts
+++ b/libs/src/oracle-sdk-v1/services/erc20.ts
@@ -13,13 +13,16 @@ import type { Erc20Props } from "../types/state";
 const batchProps: Calls = [["symbol"], ["name"], ["decimals"], ["totalSupply"]];
 export class Erc20 {
   public contract: erc20.Instance;
-  constructor(protected provider: Provider, public readonly address: string) {
+  constructor(
+    protected provider: Provider,
+    public readonly address: string,
+  ) {
     this.contract = erc20.connect(address, provider);
   }
   async approve(
     signer: Signer,
     spender: string,
-    amount: BigNumberish
+    amount: BigNumberish,
   ): Promise<TransactionResponse> {
     const contract = erc20.connect(this.address, signer);
     return contract.approve(spender, amount);
@@ -40,7 +43,7 @@ export class Erc20Multicall extends Erc20 {
   constructor(
     provider: Provider,
     address: string,
-    private multicall2: Multicall2
+    private multicall2: Multicall2,
   ) {
     super(provider, address);
     this.batchRead = BatchReadWithErrors(multicall2)(this.contract);
@@ -55,7 +58,7 @@ export class Erc20Multicall extends Erc20 {
 export function factory(
   provider: Provider,
   address: string,
-  multicall2?: Multicall2
+  multicall2?: Multicall2,
 ): Erc20 {
   if (!multicall2) return new Erc20(provider, address);
   return new Erc20Multicall(provider, address, multicall2);

--- a/libs/src/oracle-sdk-v1/services/optimisticOracle.ts
+++ b/libs/src/oracle-sdk-v1/services/optimisticOracle.ts
@@ -41,7 +41,7 @@ export class OptimisticOracle implements OracleInterface {
   constructor(
     protected provider: Provider,
     protected address: string,
-    public readonly chainId: number
+    public readonly chainId: number,
   ) {
     this.contract = optimisticOracle.connect(address, provider);
   }
@@ -63,7 +63,7 @@ export class OptimisticOracle implements OracleInterface {
   };
   private setDisputeHash(
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    hash: string
+    hash: string,
   ): Request {
     return this.upsertRequest({
       requester,
@@ -75,7 +75,7 @@ export class OptimisticOracle implements OracleInterface {
   }
   private setProposeHash(
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    hash: string
+    hash: string,
   ): Request {
     return this.upsertRequest({
       requester,
@@ -87,7 +87,7 @@ export class OptimisticOracle implements OracleInterface {
   }
   private setSettleHash(
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    hash: string
+    hash: string,
   ): Request {
     return this.upsertRequest({
       requester,
@@ -116,13 +116,13 @@ export class OptimisticOracle implements OracleInterface {
       requester,
       identifier,
       timestamp,
-      ancillaryData
+      ancillaryData,
     );
     const state = await this.contract.callStatic.getState(
       requester,
       identifier,
       timestamp,
-      ancillaryData
+      ancillaryData,
     );
     return this.upsertRequest({
       ...request,
@@ -141,25 +141,25 @@ export class OptimisticOracle implements OracleInterface {
   }
   async disputePrice(
     signer: Signer,
-    { requester, identifier, timestamp, ancillaryData }: RequestKey
+    { requester, identifier, timestamp, ancillaryData }: RequestKey,
   ): Promise<TransactionResponse> {
     const contract = optimisticOracle.connect(this.address, signer);
     const tx = await contract.disputePrice(
       requester,
       identifier,
       timestamp,
-      ancillaryData
+      ancillaryData,
     );
     this.setDisputeHash(
       { requester, identifier, timestamp, ancillaryData },
-      tx.hash
+      tx.hash,
     );
     return tx;
   }
   async proposePrice(
     signer: Signer,
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    price: BigNumberish
+    price: BigNumberish,
   ): Promise<TransactionResponse> {
     const contract = optimisticOracle.connect(this.address, signer);
     const tx = await contract.proposePrice(
@@ -167,34 +167,34 @@ export class OptimisticOracle implements OracleInterface {
       identifier,
       timestamp,
       ancillaryData,
-      price
+      price,
     );
     this.setProposeHash(
       { requester, identifier, timestamp, ancillaryData },
-      tx.hash
+      tx.hash,
     );
     return tx;
   }
   async settle(
     signer: Signer,
-    { requester, identifier, timestamp, ancillaryData }: RequestKey
+    { requester, identifier, timestamp, ancillaryData }: RequestKey,
   ): Promise<TransactionResponse> {
     const contract = optimisticOracle.connect(this.address, signer);
     const tx = await contract.settle(
       requester,
       identifier,
       timestamp,
-      ancillaryData
+      ancillaryData,
     );
     this.setSettleHash(
       { requester, identifier, timestamp, ancillaryData },
-      tx.hash
+      tx.hash,
     );
     return tx;
   }
   async update(
     startBlock = 0,
-    endBlock: number | "latest" = "latest"
+    endBlock: number | "latest" = "latest",
   ): Promise<void> {
     const events = await this.contract.queryFilter({}, startBlock, endBlock);
     this.updateFromEvents(events as unknown[] as OptimisticOracleEvent[]);

--- a/libs/src/oracle-sdk-v1/services/optimisticOracleV2.ts
+++ b/libs/src/oracle-sdk-v1/services/optimisticOracleV2.ts
@@ -45,7 +45,7 @@ export class OptimisticOracleV2 implements OracleInterface {
   constructor(
     protected provider: Provider,
     protected address: string,
-    public readonly chainId: number
+    public readonly chainId: number,
   ) {
     this.contract = connect(address, provider);
   }
@@ -63,7 +63,7 @@ export class OptimisticOracleV2 implements OracleInterface {
   };
   private setDisputeHash(
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    hash: string
+    hash: string,
   ): Request {
     return this.upsertRequest({
       requester,
@@ -75,7 +75,7 @@ export class OptimisticOracleV2 implements OracleInterface {
   }
   private setProposeHash(
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    hash: string
+    hash: string,
   ): Request {
     return this.upsertRequest({
       requester,
@@ -87,7 +87,7 @@ export class OptimisticOracleV2 implements OracleInterface {
   }
   private setSettleHash(
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    hash: string
+    hash: string,
   ): Request {
     return this.upsertRequest({
       requester,
@@ -116,13 +116,13 @@ export class OptimisticOracleV2 implements OracleInterface {
       requester,
       identifier,
       timestamp,
-      ancillaryData
+      ancillaryData,
     );
     const state = await this.contract.callStatic.getState(
       requester,
       identifier,
       timestamp,
-      ancillaryData
+      ancillaryData,
     );
     return this.upsertRequest({
       ...request,
@@ -150,25 +150,25 @@ export class OptimisticOracleV2 implements OracleInterface {
   }
   async disputePrice(
     signer: Signer,
-    { requester, identifier, timestamp, ancillaryData }: RequestKey
+    { requester, identifier, timestamp, ancillaryData }: RequestKey,
   ): Promise<TransactionResponse> {
     const contract = connect(this.address, signer);
     const tx = await contract.disputePrice(
       requester,
       identifier,
       timestamp,
-      ancillaryData
+      ancillaryData,
     );
     this.setDisputeHash(
       { requester, identifier, timestamp, ancillaryData },
-      tx.hash
+      tx.hash,
     );
     return tx;
   }
   async proposePrice(
     signer: Signer,
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    price: BigNumberish
+    price: BigNumberish,
   ): Promise<TransactionResponse> {
     const contract = connect(this.address, signer);
     const tx = await contract.proposePrice(
@@ -176,34 +176,34 @@ export class OptimisticOracleV2 implements OracleInterface {
       identifier,
       timestamp,
       ancillaryData,
-      price
+      price,
     );
     this.setProposeHash(
       { requester, identifier, timestamp, ancillaryData },
-      tx.hash
+      tx.hash,
     );
     return tx;
   }
   async settle(
     signer: Signer,
-    { requester, identifier, timestamp, ancillaryData }: RequestKey
+    { requester, identifier, timestamp, ancillaryData }: RequestKey,
   ): Promise<TransactionResponse> {
     const contract = connect(this.address, signer);
     const tx = await contract.settle(
       requester,
       identifier,
       timestamp,
-      ancillaryData
+      ancillaryData,
     );
     this.setSettleHash(
       { requester, identifier, timestamp, ancillaryData },
-      tx.hash
+      tx.hash,
     );
     return tx;
   }
   async update(
     startBlock = 0,
-    endBlock: number | "latest" = "latest"
+    endBlock: number | "latest" = "latest",
   ): Promise<void> {
     const events = await this.contract.queryFilter({}, startBlock, endBlock);
     this.updateFromEvents(events as unknown[] as OptimisticOracleEvent[]);

--- a/libs/src/oracle-sdk-v1/services/skinnyOptimisticOracle.ts
+++ b/libs/src/oracle-sdk-v1/services/skinnyOptimisticOracle.ts
@@ -69,7 +69,7 @@ export class SkinnyOptimisticOracle implements OracleInterface {
   constructor(
     protected provider: Provider,
     protected address: string,
-    public readonly chainId: number
+    public readonly chainId: number,
   ) {
     this.contract = skinnyOptimisticOracle.connect(address, provider);
   }
@@ -82,7 +82,7 @@ export class SkinnyOptimisticOracle implements OracleInterface {
   };
   private setDisputeHash(
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    hash: string
+    hash: string,
   ): Request {
     return this.upsertRequest({
       requester,
@@ -94,7 +94,7 @@ export class SkinnyOptimisticOracle implements OracleInterface {
   }
   private setProposeHash(
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    hash: string
+    hash: string,
   ): Request {
     return this.upsertRequest({
       requester,
@@ -106,7 +106,7 @@ export class SkinnyOptimisticOracle implements OracleInterface {
   }
   private setSettleHash(
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    hash: string
+    hash: string,
   ): Request {
     return this.upsertRequest({
       requester,
@@ -147,10 +147,10 @@ export class SkinnyOptimisticOracle implements OracleInterface {
   }
   async disputePrice(
     signer: Signer,
-    { requester, identifier, timestamp, ancillaryData }: RequestKey
+    { requester, identifier, timestamp, ancillaryData }: RequestKey,
   ): Promise<TransactionResponse> {
     const request = validateSolidityRequest(
-      this.getRequest({ requester, identifier, timestamp, ancillaryData })
+      this.getRequest({ requester, identifier, timestamp, ancillaryData }),
     );
     const contract = skinnyOptimisticOracle.connect(this.address, signer);
     const tx = await contract.disputePrice(
@@ -158,21 +158,21 @@ export class SkinnyOptimisticOracle implements OracleInterface {
       identifier,
       timestamp,
       ancillaryData,
-      request
+      request,
     );
     this.setDisputeHash(
       { requester, identifier, timestamp, ancillaryData },
-      tx.hash
+      tx.hash,
     );
     return tx;
   }
   async proposePrice(
     signer: Signer,
     { requester, identifier, timestamp, ancillaryData }: RequestKey,
-    price: BigNumberish
+    price: BigNumberish,
   ): Promise<TransactionResponse> {
     const request = validateSolidityRequest(
-      this.getRequest({ requester, identifier, timestamp, ancillaryData })
+      this.getRequest({ requester, identifier, timestamp, ancillaryData }),
     );
     const contract = skinnyOptimisticOracle.connect(this.address, signer);
     const tx = await contract.proposePrice(
@@ -181,20 +181,20 @@ export class SkinnyOptimisticOracle implements OracleInterface {
       timestamp,
       ancillaryData,
       request,
-      price
+      price,
     );
     this.setProposeHash(
       { requester, identifier, timestamp, ancillaryData },
-      tx.hash
+      tx.hash,
     );
     return tx;
   }
   async settle(
     signer: Signer,
-    { requester, identifier, timestamp, ancillaryData }: RequestKey
+    { requester, identifier, timestamp, ancillaryData }: RequestKey,
   ): Promise<TransactionResponse> {
     const request = validateSolidityRequest(
-      this.getRequest({ requester, identifier, timestamp, ancillaryData })
+      this.getRequest({ requester, identifier, timestamp, ancillaryData }),
     );
     const contract = skinnyOptimisticOracle.connect(this.address, signer);
     const tx = await contract.settle(
@@ -202,17 +202,17 @@ export class SkinnyOptimisticOracle implements OracleInterface {
       identifier,
       timestamp,
       ancillaryData,
-      request
+      request,
     );
     this.setSettleHash(
       { requester, identifier, timestamp, ancillaryData },
-      tx.hash
+      tx.hash,
     );
     return tx;
   }
   async update(
     startBlock = 0,
-    endBlock: number | "latest" = "latest"
+    endBlock: number | "latest" = "latest",
   ): Promise<void> {
     const events = await this.contract.queryFilter({}, startBlock, endBlock);
     this.updateFromEvents(events as unknown[] as OptimisticOracleEvent[]);

--- a/libs/src/oracle-sdk-v1/services/statemachines/approve.ts
+++ b/libs/src/oracle-sdk-v1/services/statemachines/approve.ts
@@ -29,11 +29,11 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       const { chainId, currency, spender, amount, account, signer } = params;
       assert(
         chainId === (await signer.getChainId()),
-        "Signer on wrong chainid"
+        "Signer on wrong chainid",
       );
       assert(
         account === (await signer.getAddress()),
-        "Signer on wrong account"
+        "Signer on wrong account",
       );
 
       // create service if it does not exist

--- a/libs/src/oracle-sdk-v1/services/statemachines/disputePrice.ts
+++ b/libs/src/oracle-sdk-v1/services/statemachines/disputePrice.ts
@@ -34,7 +34,7 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       } = params;
       assert(
         chainId === (await signer.getChainId()),
-        "Signer on wrong chainid"
+        "Signer on wrong chainid",
       );
 
       const oracle = store.read().oracleService(chainId);

--- a/libs/src/oracle-sdk-v1/services/statemachines/pollActiveRequest.ts
+++ b/libs/src/oracle-sdk-v1/services/statemachines/pollActiveRequest.ts
@@ -19,7 +19,7 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
     async start(
       params: Params,
       memory: Memory,
-      ctx: ContextClient
+      ctx: ContextClient,
     ): Promise<void | undefined> {
       const request = await ignoreExistenceErrorAsync(store.read().request);
       // requests can change externally if not already in one of these states

--- a/libs/src/oracle-sdk-v1/services/statemachines/proposePrice.ts
+++ b/libs/src/oracle-sdk-v1/services/statemachines/proposePrice.ts
@@ -36,13 +36,13 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       } = params;
       assert(
         chainId === (await signer.getChainId()),
-        "Signer on wrong chainid"
+        "Signer on wrong chainid",
       );
       const oracle = store.read().oracleService(chainId);
       const tx = await oracle.proposePrice(
         signer,
         { requester, identifier, timestamp, ancillaryData },
-        proposedPrice
+        proposedPrice,
       );
       memory.hash = tx.hash;
       return "confirm";

--- a/libs/src/oracle-sdk-v1/services/statemachines/setActiveRequestByTransaction.ts
+++ b/libs/src/oracle-sdk-v1/services/statemachines/setActiveRequestByTransaction.ts
@@ -22,13 +22,13 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       const receipt = await provider.getTransactionReceipt(transactionHash);
       assert(
         receipt,
-        "Unable to find transaction receipt from hash: " + transactionHash
+        "Unable to find transaction receipt from hash: " + transactionHash,
       );
       const oracle = store.read().oracleService(chainId);
       const oracleAddress = store.read().oracleAddress(chainId);
       // filter out logs that originate from oracle contract
       const oracleLogs = receipt.logs.filter(
-        (log) => log.address.toLowerCase() === oracleAddress.toLowerCase()
+        (log) => log.address.toLowerCase() === oracleAddress.toLowerCase(),
       );
       // decode logs using abi
       const decodedLogs = oracleLogs.map((log) => oracle.parseLog(log));
@@ -38,27 +38,27 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       // we dont actually know the type of the log, so we need to do some validation before continuing
       assert(
         log,
-        `Unable to find optimistic oracle event at ${transactionHash} eventIndex ${eventIndex}`
+        `Unable to find optimistic oracle event at ${transactionHash} eventIndex ${eventIndex}`,
       );
       assert(
         log.args,
-        `Unable to find optimistic oracle event args at ${transactionHash} eventIndex ${eventIndex}`
+        `Unable to find optimistic oracle event args at ${transactionHash} eventIndex ${eventIndex}`,
       );
       assert(
         log.args.timestamp,
-        `Unable to find optimistic oracle event.timestamp at ${transactionHash} eventIndex ${eventIndex}`
+        `Unable to find optimistic oracle event.timestamp at ${transactionHash} eventIndex ${eventIndex}`,
       );
       assert(
         log.args.requester,
-        `Unable to find optimistic oracle event.requester at ${transactionHash} eventIndex ${eventIndex}`
+        `Unable to find optimistic oracle event.requester at ${transactionHash} eventIndex ${eventIndex}`,
       );
       assert(
         log.args.ancillaryData,
-        `Unable to find optimistic oracle event.ancillaryData at ${transactionHash} eventIndex ${eventIndex}`
+        `Unable to find optimistic oracle event.ancillaryData at ${transactionHash} eventIndex ${eventIndex}`,
       );
       assert(
         log.args.identifier,
-        `Unable to find optimistic oracle event.identifier at ${transactionHash} eventIndex ${eventIndex}`
+        `Unable to find optimistic oracle event.identifier at ${transactionHash} eventIndex ${eventIndex}`,
       );
 
       // we can parse out the necessary params to kick off fetching the state of the request

--- a/libs/src/oracle-sdk-v1/services/statemachines/settle.ts
+++ b/libs/src/oracle-sdk-v1/services/statemachines/settle.ts
@@ -34,7 +34,7 @@ export function Handlers(store: Store): GenericHandlers<Params, Memory> {
       } = params;
       assert(
         chainId === (await signer.getChainId()),
-        "Signer on wrong chainid"
+        "Signer on wrong chainid",
       );
 
       const oracle = store.read().oracleService(chainId);

--- a/libs/src/oracle-sdk-v1/services/statemachines/statemachine.ts
+++ b/libs/src/oracle-sdk-v1/services/statemachines/statemachine.ts
@@ -91,7 +91,7 @@ export class StateMachine {
         ContextType.setUser,
         setUser.Handlers(store),
         setUser.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.clearUser]: new ContextManager<
         clearUser.Params,
@@ -100,7 +100,7 @@ export class StateMachine {
         ContextType.clearUser,
         clearUser.Handlers(store),
         clearUser.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.setActiveRequest]: new ContextManager<
         setActiveRequest.Params,
@@ -109,13 +109,13 @@ export class StateMachine {
         ContextType.setActiveRequest,
         setActiveRequest.Handlers(store),
         setActiveRequest.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.approve]: new ContextManager<approve.Params, approve.Memory>(
         ContextType.approve,
         approve.Handlers(store),
         approve.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.disputePrice]: new ContextManager<
         disputePrice.Params,
@@ -124,7 +124,7 @@ export class StateMachine {
         ContextType.disputePrice,
         disputePrice.Handlers(store),
         disputePrice.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.proposePrice]: new ContextManager<
         proposePrice.Params,
@@ -133,7 +133,7 @@ export class StateMachine {
         ContextType.proposePrice,
         proposePrice.Handlers(store),
         proposePrice.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.switchOrAddChain]: new ContextManager<
         switchOrAddChain.Params,
@@ -142,7 +142,7 @@ export class StateMachine {
         ContextType.switchOrAddChain,
         switchOrAddChain.Handlers(store),
         switchOrAddChain.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.pollActiveRequest]: new ContextManager<
         pollActiveRequest.Params,
@@ -151,7 +151,7 @@ export class StateMachine {
         ContextType.pollActiveRequest,
         pollActiveRequest.Handlers(store),
         pollActiveRequest.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.pollActiveUser]: new ContextManager<
         pollActiveUser.Params,
@@ -160,7 +160,7 @@ export class StateMachine {
         ContextType.pollActiveUser,
         pollActiveUser.Handlers(store),
         pollActiveUser.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.fetchPastEvents]: new ContextManager<
         fetchPastEvents.Params,
@@ -169,7 +169,7 @@ export class StateMachine {
         ContextType.fetchPastEvents,
         fetchPastEvents.Handlers(store),
         fetchPastEvents.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.pollNewEvents]: new ContextManager<
         pollNewEvents.Params,
@@ -178,7 +178,7 @@ export class StateMachine {
         ContextType.pollNewEvents,
         pollNewEvents.Handlers(store),
         pollNewEvents.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.setActiveRequestByTransaction]: new ContextManager<
         setActiveRequestByTransaction.Params,
@@ -187,13 +187,13 @@ export class StateMachine {
         ContextType.setActiveRequestByTransaction,
         setActiveRequestByTransaction.Handlers(store),
         setActiveRequestByTransaction.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.settle]: new ContextManager<settle.Params, settle.Memory>(
         ContextType.settle,
         settle.Handlers(store),
         settle.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
       [ContextType.updateActiveRequest]: new ContextManager<
         updateActiveRequest.Params,
@@ -202,7 +202,7 @@ export class StateMachine {
         ContextType.updateActiveRequest,
         updateActiveRequest.Handlers(store),
         updateActiveRequest.initMemory,
-        this.handleCreate
+        this.handleCreate,
       ),
     };
   }
@@ -247,14 +247,14 @@ export class StateMachine {
         case ContextType.setUser: {
           next = await this.types[context.type].step(
             context as unknown as Context<setUser.Params, setUser.Memory>,
-            now
+            now,
           );
           break;
         }
         case ContextType.clearUser: {
           next = await this.types[context.type].step(
             context as unknown as Context<clearUser.Params, clearUser.Memory>,
-            now
+            now,
           );
           break;
         }
@@ -264,14 +264,14 @@ export class StateMachine {
               setActiveRequest.Params,
               setActiveRequest.Memory
             >,
-            now
+            now,
           );
           break;
         }
         case ContextType.approve: {
           next = await this.types[context.type].step(
             context as unknown as Context<approve.Params, approve.Memory>,
-            now
+            now,
           );
           break;
         }
@@ -281,7 +281,7 @@ export class StateMachine {
               disputePrice.Params,
               disputePrice.Memory
             >,
-            now
+            now,
           );
           break;
         }
@@ -291,7 +291,7 @@ export class StateMachine {
               proposePrice.Params,
               proposePrice.Memory
             >,
-            now
+            now,
           );
           break;
         }
@@ -301,7 +301,7 @@ export class StateMachine {
               switchOrAddChain.Params,
               switchOrAddChain.Memory
             >,
-            now
+            now,
           );
           break;
         }
@@ -311,7 +311,7 @@ export class StateMachine {
               pollActiveRequest.Params,
               pollActiveRequest.Memory
             >,
-            now
+            now,
           );
           break;
         }
@@ -321,7 +321,7 @@ export class StateMachine {
               pollActiveUser.Params,
               pollActiveUser.Memory
             >,
-            now
+            now,
           );
           break;
         }
@@ -331,7 +331,7 @@ export class StateMachine {
               fetchPastEvents.Params,
               fetchPastEvents.Memory
             >,
-            now
+            now,
           );
           break;
         }
@@ -341,7 +341,7 @@ export class StateMachine {
               pollNewEvents.Params,
               pollNewEvents.Memory
             >,
-            now
+            now,
           );
           break;
         }
@@ -351,14 +351,14 @@ export class StateMachine {
               setActiveRequestByTransaction.Params,
               setActiveRequestByTransaction.Memory
             >,
-            now
+            now,
           );
           break;
         }
         case ContextType.settle: {
           next = await this.types[context.type].step(
             context as unknown as Context<settle.Params, settle.Memory>,
-            now
+            now,
           );
           break;
         }
@@ -368,7 +368,7 @@ export class StateMachine {
               updateActiveRequest.Params,
               updateActiveRequest.Memory
             >,
-            now
+            now,
           );
           break;
         }

--- a/libs/src/oracle-sdk-v1/services/statemachines/utils.ts
+++ b/libs/src/oracle-sdk-v1/services/statemachines/utils.ts
@@ -20,7 +20,7 @@ export class ContextClient {
 
 export const Step =
   <P = undefined, M extends Memory = undefined>(
-    handlers: Handlers<P, M>
+    handlers: Handlers<P, M>,
   ): StepType<P, M> =>
   async (context: Context<P, M>, now: number): Promise<Context<P, M>> => {
     assert(!context.done, "Context has ended");
@@ -56,7 +56,7 @@ export const Step =
 
 export function shouldStep(
   context: Context<unknown, unknown & Memory> | undefined,
-  now: number
+  now: number,
 ): context is Context {
   if (!context) return false;
   if (context.done) return false;
@@ -70,7 +70,7 @@ export function create<P, M extends Memory>(
   params: P,
   memory: M,
   override: Partial<ContextProps> = {},
-  now = Date.now()
+  now = Date.now(),
 ): Context<P, M> {
   const context: Context<P, M> = {
     id: uid(type + "_"),
@@ -92,7 +92,7 @@ export class ContextManager<P, M extends Memory> {
     private type: ContextType,
     private handlers: Handlers<P, M>,
     private initMemory: (params: P) => M,
-    private emit: (ctx: Context<P, M>) => void
+    private emit: (ctx: Context<P, M>) => void,
   ) {}
   create = (params: P, user?: string): string => {
     const context = create<P, M>(this.type, params, this.initMemory(params), {
@@ -105,7 +105,7 @@ export class ContextManager<P, M extends Memory> {
   async step(
     context: Context<P, M>,
     now: number = Date.now(),
-    iterations = 10
+    iterations = 10,
   ): Promise<Context<P, M>> {
     const step = Step<P, M>(this.handlers);
     let next = context;
@@ -113,7 +113,7 @@ export class ContextManager<P, M extends Memory> {
       assert(
         iterations >= 0,
         "Infinite loop detected in state machine, make sure it each state transitions to done: " +
-          context.type
+          context.type,
       );
       next = await step(next, now);
       iterations--;

--- a/libs/src/oracle-sdk-v1/services/update.ts
+++ b/libs/src/oracle-sdk-v1/services/update.ts
@@ -41,7 +41,7 @@ export class Update {
     const oo = this.read().oracleService();
     const { defaultLiveness } = await oo.getProps();
     this.write((write) =>
-      write.chains(chainId).optimisticOracle().defaultLiveness(defaultLiveness)
+      write.chains(chainId).optimisticOracle().defaultLiveness(defaultLiveness),
     );
   };
   userCollateralBalance = async (): Promise<void> => {
@@ -50,7 +50,7 @@ export class Update {
     const token = this.read().collateralService();
     const result = await token.contract.balanceOf(account);
     this.write((write) =>
-      write.chains(chainId).erc20s(token.address).balance(account, result)
+      write.chains(chainId).erc20s(token.address).balance(account, result),
     );
   };
   collateralProps = async (): Promise<void> => {
@@ -58,7 +58,7 @@ export class Update {
     const token = this.read().collateralService();
     const props = await token.getProps();
     this.write((write) =>
-      write.chains(chainId).erc20s(token.address).props(props)
+      write.chains(chainId).erc20s(token.address).props(props),
     );
   };
   oracleAllowance = async (): Promise<void> => {
@@ -71,36 +71,36 @@ export class Update {
       write
         .chains(chainId)
         .erc20s(token.address)
-        .allowance(account, oracleAddress, result)
+        .allowance(account, oracleAddress, result),
     );
   };
   balance = async (
     chainId: number,
     token: string,
-    account: string
+    account: string,
   ): Promise<void> => {
     const tokenService = this.read().tokenService(chainId, token);
     const result = await tokenService.contract.balanceOf(account);
     this.write((write) =>
-      write.chains(chainId).erc20s(token).balance(account, result)
+      write.chains(chainId).erc20s(token).balance(account, result),
     );
   };
   allowance = async (
     chainId: number,
     token: string,
     account: string,
-    spender: string
+    spender: string,
   ): Promise<void> => {
     const tokenService = this.read().tokenService(chainId, token);
     const result = await tokenService.contract.allowance(account, spender);
     this.write((write) =>
-      write.chains(chainId).erc20s(token).allowance(account, spender, result)
+      write.chains(chainId).erc20s(token).allowance(account, spender, result),
     );
   };
   isConfirmed = async (
     chainId: number,
     hash: string,
-    confirmations: number
+    confirmations: number,
   ): Promise<boolean | TransactionReceipt> => {
     const txService = this.read().transactionService(chainId);
     return txService.isConfirmed(hash, confirmations);
@@ -109,7 +109,7 @@ export class Update {
   oracleEvents = async (
     chainId: number,
     startBlock = 0,
-    endBlock?: number
+    endBlock?: number,
   ): Promise<void> => {
     const provider = this.read().provider(chainId);
     const oracle = this.read().oracleService(chainId);

--- a/libs/src/oracle-sdk-v1/skinnyFactory.ts
+++ b/libs/src/oracle-sdk-v1/skinnyFactory.ts
@@ -9,7 +9,7 @@ import type { Emit } from "./store";
 const Factory = (
   config: state.PartialConfig,
   emit: Emit,
-  sortedRequests: SortedRequests = new SortedRequests()
+  sortedRequests: SortedRequests = new SortedRequests(),
 ): Client => {
   const fullConfig = DefaultConfig({
     getMulticall2Address,

--- a/libs/src/oracle-sdk-v1/store/index.ts
+++ b/libs/src/oracle-sdk-v1/store/index.ts
@@ -16,7 +16,10 @@ export { Write, Store, Read, Has };
  */
 export default class OracleStore {
   private store: Store<State>;
-  constructor(private emit: Emit = () => undefined, private state: State = {}) {
+  constructor(
+    private emit: Emit = () => undefined,
+    private state: State = {},
+  ) {
     this.store = new Store<State>(emit, state);
   }
   /**

--- a/libs/src/oracle-sdk-v1/store/read.ts
+++ b/libs/src/oracle-sdk-v1/store/read.ts
@@ -118,7 +118,7 @@ export default class Read {
       chain?.erc20s?.[request.currency]?.allowances?.[oracle]?.[user];
     assertExists(
       allowance,
-      "Allowance not set on user on collateral token for oracle"
+      "Allowance not set on user on collateral token for oracle",
     );
     return allowance;
   };
@@ -146,7 +146,7 @@ export default class Read {
     const result = this.state?.services?.chains?.[chainId]?.erc20s?.[address];
     assertExists(
       result,
-      `Token service not found: ${[chainId, address].join(".")}`
+      `Token service not found: ${[chainId, address].join(".")}`,
     );
     return result;
   };

--- a/libs/src/oracle-sdk-v1/store/test/store.test.ts
+++ b/libs/src/oracle-sdk-v1/store/test/store.test.ts
@@ -19,7 +19,7 @@ describe("Oracle Store", function () {
       done();
     });
     store.write((write) =>
-      write.inputs().user().set({ address: "test", chainId: 1 })
+      write.inputs().user().set({ address: "test", chainId: 1 }),
     );
   });
   test("set input", function (done) {
@@ -37,7 +37,7 @@ describe("Oracle Store", function () {
         timestamp: 1,
         ancillaryData: "d",
         chainId: 1,
-      })
+      }),
     );
   });
   test("set balance", function (done) {
@@ -46,13 +46,13 @@ describe("Oracle Store", function () {
       done();
     });
     store.write((write) =>
-      write.chains(1).erc20s("test").balance("user1", BigNumber.from(1))
+      write.chains(1).erc20s("test").balance("user1", BigNumber.from(1)),
     );
   });
   test("set allowance", function (done) {
     events.once("change", (state: State) => {
       assert.ok(
-        state.chains?.[1]?.erc20s?.test?.allowances?.oracle?.user1?.eq(1)
+        state.chains?.[1]?.erc20s?.test?.allowances?.oracle?.user1?.eq(1),
       );
       done();
     });
@@ -60,7 +60,7 @@ describe("Oracle Store", function () {
       write
         .chains(1)
         .erc20s("test")
-        .allowance("user1", "oracle", BigNumber.from(1))
+        .allowance("user1", "oracle", BigNumber.from(1)),
     );
   });
   test("get chainId", function () {

--- a/libs/src/oracle-sdk-v1/store/write.ts
+++ b/libs/src/oracle-sdk-v1/store/write.ts
@@ -61,7 +61,7 @@ export class Erc20 {
   allowance(
     account: string,
     spender: string,
-    amount: ethersTypes.BigNumber
+    amount: ethersTypes.BigNumber,
   ): void {
     if (!this.state.allowances) this.state.allowances = {};
     if (!this.state.allowances[spender]) this.state.allowances[spender] = {};
@@ -122,7 +122,7 @@ export class Services {
     this.state.erc20s[address] = Erc20Factory(
       this.state.provider,
       address,
-      this.state.multicall2
+      this.state.multicall2,
     );
   }
   optimisticOracle(optimisticOracle: OracleInterface): void {
@@ -135,7 +135,7 @@ export class Services {
     if (!this.state.provider) return;
     this.state.multicall2 = new Multicall2(
       multicall2Address,
-      this.state.provider
+      this.state.provider,
     );
   }
 }
@@ -169,7 +169,7 @@ export default class Write {
     this.state.error = error;
   }
   command(
-    context: statemachine.Context<unknown, unknown & statemachine.Memory>
+    context: statemachine.Context<unknown, unknown & statemachine.Memory>,
   ): void {
     if (!this.state.commands) this.state.commands = {};
     this.state.commands[context.id] = context;

--- a/libs/src/oracle-sdk-v1/tests/optimisticV2.e2e.ts
+++ b/libs/src/oracle-sdk-v1/tests/optimisticV2.e2e.ts
@@ -11,7 +11,7 @@ dotenv.config();
 assert(process.env.PROVIDER_URL_137, "requires PROVIDER_URL_137");
 
 const optimisticOracleAddress = getAddress(
-  "0xee3afe347d5c74317041e2618c49534daf887c24"
+  "0xee3afe347d5c74317041e2618c49534daf887c24",
 );
 const providerUrl = process.env.PROVIDER_URL_137;
 const chainId = 137;

--- a/libs/src/oracle-sdk-v1/tests/utils.test.ts
+++ b/libs/src/oracle-sdk-v1/tests/utils.test.ts
@@ -42,11 +42,11 @@ describe("Oracle Utils", function () {
     assert.equal(rangeState.currentRange, expectedRange);
     assert.equal(
       rangeState.currentEnd,
-      endBlock - Math.floor(expectedRange / 2)
+      endBlock - Math.floor(expectedRange / 2),
     );
     assert.equal(
       rangeState.currentStart,
-      endBlock - (Math.floor(expectedRange / 2) + expectedRange)
+      endBlock - (Math.floor(expectedRange / 2) + expectedRange),
     );
     assert.ok(!rangeState.done);
 

--- a/libs/src/oracle-sdk-v1/types/interfaces.ts
+++ b/libs/src/oracle-sdk-v1/types/interfaces.ts
@@ -76,12 +76,12 @@ export interface OracleInterface {
   getRequest: (props: RequestKey) => Request;
   disputePrice: (
     signer: Signer,
-    key: RequestKey
+    key: RequestKey,
   ) => Promise<TransactionResponse>;
   proposePrice: (
     signer: Signer,
     key: RequestKey,
-    price: BigNumberish
+    price: BigNumberish,
   ) => Promise<TransactionResponse>;
   settle: (signer: Signer, key: RequestKey) => Promise<TransactionResponse>;
   update: (startBlock: number, endBlock: number | "latest") => Promise<void>;

--- a/libs/src/oracle-sdk-v1/types/statemachine.ts
+++ b/libs/src/oracle-sdk-v1/types/statemachine.ts
@@ -35,7 +35,7 @@ export type ContextProps = {
 
 export type Context<
   P = undefined,
-  M extends Memory = undefined
+  M extends Memory = undefined,
 > = ContextProps & {
   memory: M;
   params: P;
@@ -44,7 +44,7 @@ export type Context<
 export type Handler<P = undefined, M extends Memory = undefined> = (
   params: P,
   memory: M,
-  client: ContextClient
+  client: ContextClient,
 ) => string | undefined | void | Promise<string | undefined | void>;
 
 export type Handlers<P = undefined, M extends Memory = undefined> = Record<
@@ -56,9 +56,9 @@ export type Handlers<P = undefined, M extends Memory = undefined> = Record<
 
 export type Step<P = undefined, M extends Memory = undefined> = (
   context: Context<P, M>,
-  now: number
+  now: number,
 ) => Promise<Context<P, M>>;
 
 export type Emit<P = undefined, M extends Memory = undefined> = (
-  context: Context<P, M>
+  context: Context<P, M>,
 ) => void;

--- a/libs/src/oracle-sdk-v1/utils.ts
+++ b/libs/src/oracle-sdk-v1/utils.ts
@@ -98,10 +98,10 @@ export function getFlags(state: State): Record<Flag, boolean> {
   if (request && request.bond && request.finalFee) {
     const totalBond = request.bond.add(request.finalFee);
     const userCollateralBalance = ignoreExistenceError(
-      read.userCollateralBalance
+      read.userCollateralBalance,
     );
     const userCollateralAllowance = ignoreExistenceError(
-      read.userCollateralAllowance
+      read.userCollateralAllowance,
     );
     flags[Flag.InsufficientBalance] = userCollateralBalance
       ? userCollateralBalance.lt(totalBond)
@@ -113,7 +113,7 @@ export function getFlags(state: State): Record<Flag, boolean> {
 
   const userAddress = ignoreExistenceError(read.userAddress);
   const commands = ignoreExistenceError(() =>
-    read.filterCommands({ done: false, user: userAddress })
+    read.filterCommands({ done: false, user: userAddress }),
   );
   if (userAddress && commands) {
     commands.forEach((command) => {
@@ -159,7 +159,7 @@ export function getMulticall2Address(chainId: number): string {
       return getAddress("0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696");
     default:
       throw new Error(
-        `No address found for deployment Multicall2 on chainId ${chainId}`
+        `No address found for deployment Multicall2 on chainId ${chainId}`,
       );
   }
 }
@@ -195,11 +195,11 @@ export const DefaultConfig =
       (config: Config, [chainId, chainConfig]) => {
         config.chains[Number(chainId)] = DefaultChainConfig(getters)(
           Number(chainId),
-          chainConfig
+          chainConfig,
         );
         return config;
       },
-      { ...config, chains: {}, oracleType }
+      { ...config, chains: {}, oracleType },
     );
   };
 
@@ -210,7 +210,7 @@ export class TransactionConfirmer {
   }
   async isConfirmed(
     hash: string,
-    confirmations = 1
+    confirmations = 1,
   ): Promise<false | TransactionReceipt> {
     try {
       const receipt = await this.getReceipt(hash);
@@ -257,7 +257,7 @@ export type RangeState = {
 export function rangeStart(
   state: Pick<RangeState, "startBlock" | "endBlock" | "multiplier"> & {
     maxRange?: number;
-  }
+  },
 ): RangeState {
   const { startBlock, endBlock, multiplier = 2 } = state;
   if (state.maxRange && state.maxRange > 0) {
@@ -384,7 +384,7 @@ export function eventKey(event: {
 export function insertOrderedAscending<T>(
   array: T[],
   element: T,
-  orderBy: (element: T) => string | number
+  orderBy: (element: T) => string | number,
 ): T[] {
   const index = sortedLastIndexBy(array, element, orderBy);
   array.splice(index, 0, element);
@@ -393,7 +393,7 @@ export function insertOrderedAscending<T>(
 export function isUnique<T>(
   array: T[],
   element: T,
-  id: (element: T) => string | number
+  id: (element: T) => string | number,
 ): boolean {
   const elementId = id(element);
   const found = array.find((next: T) => {
@@ -403,7 +403,7 @@ export function isUnique<T>(
 }
 
 export function isSupportedOracleType(
-  oracleType: string
+  oracleType: string,
 ): oracleType is OracleType {
   return oracleType in OracleType;
 }

--- a/libs/src/oracle-sdk-v2/client.ts
+++ b/libs/src/oracle-sdk-v2/client.ts
@@ -1,14 +1,14 @@
 import type { Handlers, ServiceFactories } from "./types";
 
 const isRejected = (
-  input: PromiseSettledResult<unknown>
+  input: PromiseSettledResult<unknown>,
 ): input is PromiseRejectedResult => input.status === "rejected";
 
 export function Client(factories: ServiceFactories, handlers: Handlers) {
   const services = factories.map((factory) => factory(handlers));
   async function tick() {
     const results = await Promise.allSettled(
-      services.map((service) => (service ? service.tick() : undefined))
+      services.map((service) => (service ? service.tick() : undefined)),
     );
     const errors: (Error | undefined)[] = results.map((result) => {
       if (isRejected(result)) {
@@ -27,7 +27,7 @@ export function Client(factories: ServiceFactories, handlers: Handlers) {
   // on an interval, but it depends on the source of data.
   setTimeout(() => {
     tick().catch((err) =>
-      console.error("Uncaught error in oracle service:", err)
+      console.error("Uncaught error in oracle service:", err),
     );
   });
 }

--- a/libs/src/oracle-sdk-v2/services/oracles/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oracles/factory.ts
@@ -29,7 +29,7 @@ export const Factory = (config: Config): ServiceFactory[] => {
         return gql3.Factory(config)(handlers);
       }
       throw new Error(
-        `Unsupported oracle type ${config.type} from ${config.source}`
+        `Unsupported oracle type ${config.type} from ${config.source}`,
       );
     };
   });

--- a/libs/src/oracle-sdk-v2/services/oraclev1/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/ethers/factory.ts
@@ -55,7 +55,7 @@ const AddTimestamps =
     }
     if (request.settlementBlockNumber && !request.settlementTimestamp) {
       const block = await provider.getBlock(
-        Number(request.settlementBlockNumber)
+        Number(request.settlementBlockNumber),
       );
       request.settlementTimestamp = block.timestamp.toString();
     }
@@ -155,7 +155,7 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
   const convertToSharedRequest = ConvertToSharedRequest(
     config.chainId,
     assertAddress(config.address),
-    "Optimistic Oracle V1"
+    "Optimistic Oracle V1",
   );
   const provider = new ethers.providers.JsonRpcProvider(config.url);
   const oo = new OptimisticOracle(provider, config.address, config.chainId);
@@ -166,7 +166,7 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
       oo.updateFromTransactionReceipt(receipt);
       const requests: Request[] = oo.listRequests();
       const sharedRequests = requests.map((request) =>
-        convertToSharedRequest(request)
+        convertToSharedRequest(request),
       );
       events.emit("requests", sharedRequests);
     } catch (err) {
@@ -194,17 +194,17 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
         await queryRange(startBlock, endBlock);
         const requests = oo.listRequests();
         const convertedRequests: SharedRequest[] = Object.values(requests).map(
-          convertToSharedRequest
+          convertToSharedRequest,
         );
         const requestsWithTimestamps = await Promise.all(
-          convertedRequests.map(addTimestamps)
+          convertedRequests.map(addTimestamps),
         );
         events.emit("requests", requestsWithTimestamps);
       })
       .catch((err) => {
         console.warn(
           "error querying latest OOV1 requests from web3 provider:",
-          err
+          err,
         );
         events.emit("error", err);
       });

--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/factory.ts
@@ -17,7 +17,12 @@ export const Factory =
     async function fetch({ url, chainId, address, type }: Config) {
       const requests = await getPriceRequests(url, chainId, type);
       return requests.map((request) =>
-        parsePriceRequestGraphEntity(request, chainId, address as Address, type)
+        parsePriceRequestGraphEntity(
+          request,
+          chainId,
+          address as Address,
+          type,
+        ),
       );
     }
     async function tick() {

--- a/libs/src/oracle-sdk-v2/services/oraclev2/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev2/ethers/factory.ts
@@ -55,7 +55,7 @@ const AddTimestamps =
     }
     if (request.settlementBlockNumber && !request.settlementTimestamp) {
       const block = await provider.getBlock(
-        Number(request.settlementBlockNumber)
+        Number(request.settlementBlockNumber),
       );
       request.settlementTimestamp = block.timestamp.toString();
     }
@@ -155,7 +155,7 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
   const convertToSharedRequest = ConvertToSharedRequest(
     config.chainId,
     assertAddress(config.address),
-    "Optimistic Oracle V2"
+    "Optimistic Oracle V2",
   );
   const provider = new ethers.providers.JsonRpcProvider(config.url);
   const oo = new OptimisticOracleV2(provider, config.address, config.chainId);
@@ -166,7 +166,7 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
       oo.updateFromTransactionReceipt(receipt);
       const requests: Request[] = oo.listRequests();
       const sharedRequests = requests.map((request) =>
-        convertToSharedRequest(request)
+        convertToSharedRequest(request),
       );
       events.emit("requests", sharedRequests);
     } catch (err) {
@@ -194,17 +194,17 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
         await queryRange(startBlock, endBlock);
         const requests = oo.listRequests();
         const convertedRequests: SharedRequest[] = Object.values(requests).map(
-          convertToSharedRequest
+          convertToSharedRequest,
         );
         const requestsWithTimestamps = await Promise.all(
-          convertedRequests.map(addTimestamps)
+          convertedRequests.map(addTimestamps),
         );
         events.emit("requests", requestsWithTimestamps);
       })
       .catch((err) => {
         console.warn(
           "error querying latest OOV2 requests from web3 provider:",
-          err
+          err,
         );
         events.emit("error", err);
       });

--- a/libs/src/oracle-sdk-v2/services/oraclev3/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/ethers/factory.ts
@@ -47,19 +47,19 @@ const AddTimestamps =
   async (assertion: SharedAssertion): Promise<SharedAssertion> => {
     if (assertion.assertionBlockNumber && !assertion.assertionTimestamp) {
       const block = await provider.getBlock(
-        Number(assertion.assertionBlockNumber)
+        Number(assertion.assertionBlockNumber),
       );
       assertion.assertionTimestamp = block.timestamp.toString();
     }
     if (assertion.disputeBlockNumber && !assertion.disputeTimestamp) {
       const block = await provider.getBlock(
-        Number(assertion.disputeBlockNumber)
+        Number(assertion.disputeBlockNumber),
       );
       assertion.disputeTimestamp = block.timestamp.toString();
     }
     if (assertion.settlementBlockNumber && !assertion.settlementTimestamp) {
       const block = await provider.getBlock(
-        Number(assertion.settlementBlockNumber)
+        Number(assertion.settlementBlockNumber),
       );
       assertion.settlementTimestamp = block.timestamp.toString();
     }
@@ -156,7 +156,7 @@ export type Api = {
 export const Factory = (config: Config): [ServiceFactory, Api] => {
   const convertToSharedAssertion = ConvertToSharedAssertion(
     config.chainId,
-    assertAddress(config.address)
+    assertAddress(config.address),
   );
   const provider = new ethers.providers.JsonRpcProvider(config.url);
   const addTimestamps = AddTimestamps(provider);
@@ -188,10 +188,10 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
         .filter((x) => x);
 
       const { assertions = {} } = getEventState(
-        parsedLogs as unknown as SerializableEvent[]
+        parsedLogs as unknown as SerializableEvent[],
       );
       const sharedAssertions = Object.values(assertions).map((assertion) =>
-        convertToSharedAssertion(assertion)
+        convertToSharedAssertion(assertion),
       );
       Promise.all(sharedAssertions.map(addTimestamps))
         .then((sharedAssertions) => {
@@ -222,7 +222,7 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
       const eventLogs = await contract.queryFilter(
         {},
         currentStart,
-        currentEnd
+        currentEnd,
       );
       updateFromEvents(eventLogs as unknown[] as OptimisticOracleEvent[]);
       rangeState = rangeSuccessDescending({ ...rangeState, multiplier: 1 });
@@ -238,10 +238,10 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
         await queryRange(startBlock, endBlock);
         const { assertions = {} } = getEventState(logs);
         const convertedAssertions = Object.values(assertions).map(
-          convertToSharedAssertion
+          convertToSharedAssertion,
         );
         const assertionsWithTimestamps = await Promise.all(
-          convertedAssertions.map(addTimestamps)
+          convertedAssertions.map(addTimestamps),
         );
         events.emit("assertions", assertionsWithTimestamps);
       })

--- a/libs/src/oracle-sdk-v2/services/oraclev3/gql/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/gql/factory.ts
@@ -16,7 +16,7 @@ export const Factory =
     async function fetch({ url, chainId, address }: Config) {
       const requests = await getAssertions(url, chainId);
       return requests.map((request) =>
-        parseAssertionGraphEntity(request, chainId, address as Address)
+        parseAssertionGraphEntity(request, chainId, address as Address),
       );
     }
     async function tick() {

--- a/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
@@ -16,7 +16,7 @@ async function fetchAllAssertions(url: string, queryName: string) {
   const first = 500;
   let assertions = await fetchAssertions(
     url,
-    makeQuery(queryName, first, skip)
+    makeQuery(queryName, first, skip),
   );
 
   while (assertions.length > 0) {

--- a/libs/src/types.ts
+++ b/libs/src/types.ts
@@ -12,9 +12,7 @@ export type {
   TransactionResponse,
 } from "@ethersproject/abstract-provider";
 
-export type {
-  WaitForTransactionResult,
-} from "@wagmi/core";
+export type { WaitForTransactionResult } from "@wagmi/core";
 
 type Result = ethers.utils.Result;
 export type { Result, BigNumberish };
@@ -38,9 +36,7 @@ export type SignerOrProvider =
   | providers.Provider
   | providers.BaseProvider
   | Signer
-  | Provider
-  | providers.JsonRpcProvider
-  | ethers.Signer;
+  | providers.JsonRpcProvider;
 
 export type SerializableEvent = Omit<
   Event,
@@ -58,7 +54,7 @@ export type SerializableEvent = Omit<
 // to a version where Ethers events are exported as first class types.
 export type GetEventType<
   ContractType extends Contract,
-  EventName extends string
+  EventName extends string,
 > = ReturnType<
   ContractType["filters"][EventName] extends Callable
     ? ContractType["filters"][EventName]

--- a/libs/src/utils.ts
+++ b/libs/src/utils.ts
@@ -10,7 +10,7 @@ export type BigNumberish = number | string | BigNumber;
 // "is" syntax: https://stackoverflow.com/questions/40081332/what-does-the-is-keyword-do-in-typescript
 /* eslint-disable-next-line @typescript-eslint/ban-types */
 export function exists<T>(
-  value: T | null | undefined
+  value: T | null | undefined,
 ): value is NonNullable<T> {
   return value !== null && value !== undefined;
 }
@@ -94,7 +94,7 @@ export const BatchReadWithErrors =
     const results = await multicall2
       .batch(
         contract,
-        calls.map(([method, ...args]) => ({ method, args }))
+        calls.map(([method, ...args]) => ({ method, args })),
       )
       .readWithErrors();
     // convert results of multicall, an array of responses, into an object keyed by contract method
@@ -104,7 +104,7 @@ export const BatchReadWithErrors =
         const [method] = call;
         if (!result?.result) return [method, undefined];
         return [method, result.result[0] || result.result];
-      })
+      }),
     ) as R;
   };
 
@@ -114,7 +114,7 @@ export const BatchReadWithErrors =
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
 export async function averageBlockTimeSeconds(
   lookbackSeconds?: number,
-  networkId?: number
+  networkId?: number,
 ): Promise<number> {
   // TODO: Call an external API to get this data. Currently this value is a hard-coded estimate
   // based on the data from https://etherscan.io/chart/blocktime. ~13.5 seconds has been the average
@@ -137,7 +137,7 @@ export async function averageBlockTimeSeconds(
 
 export async function estimateBlocksElapsed(
   seconds: number,
-  cushionPercentage = 0.0
+  cushionPercentage = 0.0,
 ): Promise<number> {
   const cushionMultiplier = cushionPercentage + 1.0;
   const averageBlockTime = await averageBlockTimeSeconds();
@@ -174,7 +174,7 @@ export function eventKey(event: {
 export function insertOrderedAscending<T>(
   array: T[],
   element: T,
-  orderBy: (element: T) => string | number
+  orderBy: (element: T) => string | number,
 ): T[] {
   const index = sortedLastIndexBy(array, element, orderBy);
   array.splice(index, 0, element);
@@ -183,7 +183,7 @@ export function insertOrderedAscending<T>(
 export function isUnique<T>(
   array: T[],
   element: T,
-  id: (element: T) => string | number
+  id: (element: T) => string | number,
 ): boolean {
   const elementId = id(element);
   const found = array.find((next: T) => {
@@ -225,7 +225,7 @@ export type RangeState = {
 export function rangeStart(
   state: Pick<RangeState, "startBlock" | "endBlock" | "multiplier"> & {
     maxRange?: number;
-  }
+  },
 ): RangeState {
   const { startBlock, endBlock, multiplier = 2 } = state;
   if (state.maxRange && state.maxRange > 0) {

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -48,6 +48,7 @@ const [oracleEthersServices, oracleEthersApis] = config.providers
     if (config.type === "Optimistic Oracle V3")
       return [config, ...oracle3Ethers.Factory(config)];
     // skinny optimistic oracle is left
+    console.log("making skinny", config);
     return [config, ...skinny1Ethers.Factory(config)];
   })
   .reduce(

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -48,7 +48,6 @@ const [oracleEthersServices, oracleEthersApis] = config.providers
     if (config.type === "Optimistic Oracle V3")
       return [config, ...oracle3Ethers.Factory(config)];
     // skinny optimistic oracle is left
-    console.log("making skinny", config);
     return [config, ...skinny1Ethers.Factory(config)];
   })
   .reduce(

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -271,9 +271,10 @@ export function useProposeAction({
   });
   useEffect(() => {
     if (!query?.id) return;
-    refetchConfig().catch((err) =>
-      console.warn("error refetching config", err),
-    );
+    refetchConfig &&
+      refetchConfig().catch((err) =>
+        console.warn("error refetching config", err),
+      );
     resetContractWrite();
   }, [query?.id, refetchConfig, resetContractWrite]);
   // notify based on proposal tx
@@ -368,9 +369,10 @@ export function useDisputeAction({
   });
   useEffect(() => {
     if (!query?.id) return;
-    refetchConfig().catch((err) =>
-      console.warn("error refetching config", err),
-    );
+    refetchConfig &&
+      refetchConfig().catch((err) =>
+        console.warn("error refetching config", err),
+      );
     resetContractWrite();
   }, [query?.id, refetchConfig, resetContractWrite]);
   // notify based on dispute tx
@@ -451,9 +453,10 @@ export function useDisputeAssertionAction({
 
   useEffect(() => {
     if (!query?.id) return;
-    refetchConfig().catch((err) =>
-      console.warn("error refetching config", err),
-    );
+    refetchConfig &&
+      refetchConfig().catch((err) =>
+        console.warn("error refetching config", err),
+      );
     resetContractWrite();
   }, [query?.id, refetchConfig, resetContractWrite]);
   // notify based on dispute tx
@@ -535,9 +538,10 @@ export function useSettlePriceAction({
   });
   useEffect(() => {
     if (!query?.id) return;
-    refetchConfig().catch((err) =>
-      console.warn("error refetching config", err),
-    );
+    refetchConfig &&
+      refetchConfig().catch((err) =>
+        console.warn("error refetching config", err),
+      );
     resetContractWrite();
   }, [query?.id, refetchConfig, resetContractWrite]);
   useEffect(() => {
@@ -573,6 +577,7 @@ export function useSettlePriceAction({
       disabledReason: "Settling...",
     };
   }
+  // console.log(query)
   // unique to settle, if we have an error preparing the transaction,
   // this means this is probably disputed, but no answer available from dvm yet
   if (prepareSettlePriceError) {
@@ -623,9 +628,10 @@ export function useSettleAssertionAction({
   });
   useEffect(() => {
     if (!query?.id) return;
-    refetchConfig().catch((err) =>
-      console.warn("error refetching config", err),
-    );
+    refetchConfig &&
+      refetchConfig().catch((err) =>
+        console.warn("error refetching config", err),
+      );
     resetContractWrite();
   }, [query?.id, refetchConfig, resetContractWrite]);
   useEffect(() => {


### PR DESCRIPTION
## motivation
we werent able to settle some across proposals. This was due to missing data on gql

## changes
This adds bond and customLiveness to the gql query for skinny data.  This enables the currently blocked across proposals from settling.  Accidentally linted the library folder as well which is why theres a bunch of other changes.