### PR TITLE
feat: show migration banner if using legacy plugin

### DIFF
--- a/libs/src/types.ts
+++ b/libs/src/types.ts
@@ -3,7 +3,6 @@ import type {
   TypedEventFilterEthers as TypedEventFilter,
   TypedEventEthers as TypedEvent,
 } from "@uma/contracts-frontend";
-import type { Provider } from "@ethersproject/providers";
 import type { Signer } from "@ethersproject/abstract-signer";
 export type { Log } from "@ethersproject/abstract-provider";
 export type {

--- a/src/components/Panel/Actions/Actions.tsx
+++ b/src/components/Panel/Actions/Actions.tsx
@@ -43,7 +43,7 @@ export function Actions({ query }: Props) {
 
   const pageIsPropose = page === "propose";
   const pageIsSettled = page === "settled";
-  const pageIsVerify = true; // page === "verify"; // TODO: revert
+  const pageIsVerify = page === "verify";
   const hasAction = primaryAction !== undefined;
   const noAction = !hasAction;
   const actionIsDispute = actionType === "dispute";

--- a/src/components/Panel/Actions/Actions.tsx
+++ b/src/components/Panel/Actions/Actions.tsx
@@ -16,8 +16,7 @@ import { Errors } from "./Errors";
 import { Message } from "./Message";
 import { PrimaryActionButton } from "./PrimaryActionButton";
 import { ProposeInput } from "./ProposeInput";
-import { TenderlySimulation } from "../TenderlySimulation";
-import { useSnapPluginData } from "@/helpers/snapshot";
+import { SimulateIfOsnap } from "../TenderlySimulation";
 
 interface Props {
   query: OracleQueryUI;
@@ -44,7 +43,7 @@ export function Actions({ query }: Props) {
 
   const pageIsPropose = page === "propose";
   const pageIsSettled = page === "settled";
-  const pageIsVerify = page === "verify";
+  const pageIsVerify = true; // page === "verify"; // TODO: revert
   const hasAction = primaryAction !== undefined;
   const noAction = !hasAction;
   const actionIsDispute = actionType === "dispute";
@@ -69,7 +68,6 @@ export function Actions({ query }: Props) {
   const actionsTitle = getActionsTitle();
   const actionsIcon = pageIsSettled ? <Settled /> : <Pencil />;
   const valueToShow = maybeGetValueTextFromOptions(valueText, proposeOptions);
-  const osnapData = useSnapPluginData(queryText);
 
   function getActionsTitle() {
     if (pageIsSettled) return "Settled as";
@@ -111,9 +109,7 @@ export function Actions({ query }: Props) {
       {!pageIsSettled && <Details {...query} />}
       {showPrimaryActionButton && <PrimaryActionButton {...primaryAction} />}
       {showConnectButton && <ConnectButton />}
-      {osnapData && pageIsVerify && (
-        <TenderlySimulation osnapPluginData={osnapData.oSnap} />
-      )}
+      {pageIsVerify && <SimulateIfOsnap queryText={queryText} />}
 
       <Message
         query={query}

--- a/src/components/Panel/TenderlySimulation.tsx
+++ b/src/components/Panel/TenderlySimulation.tsx
@@ -12,10 +12,44 @@ import { LoadingSpinner } from "../LoadingSpinner";
 import ExternalLink from "public/assets/icons/external-link-2.svg";
 import Refresh from "public/assets/icons/refresh.svg";
 import { cn } from "@/helpers";
+import { useOsnapPluginData } from "@/helpers/snapshot";
+import Warning from "public/assets/icons/warning.svg";
+import Link from "next/link";
 
-type SimulationProps = {
-  osnapPluginData: OsnapPluginData["oSnap"];
+type Props = {
+  queryText: string | undefined;
 };
+
+export function SimulateIfOsnap({ queryText }: Props) {
+  const pluginData = useOsnapPluginData(queryText);
+
+  if (!pluginData) {
+    return;
+  }
+
+  if (pluginData === "safeSnap") {
+    return (
+      <div className="text-sm flex items-start justify-start gap-1 py-1 w-panel-content-width">
+        <div className="leading-6 h-6 w-6 flex items-center justify-center">
+          <Warning className="h-[1em] w-[1em]" />
+        </div>
+
+        <p className="leading-6">
+          Tenderly Simulation not available. Please migrate to the official{" "}
+          <Link
+            className="text-red-500 hover:underline "
+            target="_blank"
+            href="https://docs.uma.xyz/developers/osnap/osnap-configuration-parameters-1"
+          >
+            oSnap plugin.
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return <TenderlySimulation osnapPluginData={pluginData} />;
+}
 
 type SimulationState =
   | {
@@ -41,7 +75,11 @@ type SimulationState =
       status: "IDLE";
     };
 
-export function TenderlySimulation({ osnapPluginData }: SimulationProps) {
+type SimulationProps = {
+  osnapPluginData: OsnapPluginData["oSnap"];
+};
+
+function TenderlySimulation({ osnapPluginData }: SimulationProps) {
   const [status, setStatus] = useState<SimulationState>({
     status: "IDLE",
   });
@@ -87,7 +125,7 @@ export function TenderlySimulation({ osnapPluginData }: SimulationProps) {
   }
 
   return (
-    <div className="w-full mt-2">
+    <div className="w-panel-content-width mt-2 ">
       {!(status.status === "SUCCESS" || status.status === "FAIL") ? (
         <button
           disabled={status.status === "LOADING"}

--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -23,6 +23,7 @@ export function useSnapPluginData(queryText: string | undefined) {
     return getOsnapProposalPluginData(ipfsProposalData.data);
   }
 }
+
 export function useIpfs(hash?: string) {
   return useSWR(hash ? `/ipfs/${hash}` : null, () => {
     assert(hash, "Missing ipfs hash");
@@ -39,7 +40,7 @@ export function snapshotProposalLink(ipfsData: unknown) {
 
   if (space && hash) {
     return {
-      link: `http://localhost:8080/#/${space}/proposal/${hash}`,
+      link: `https://snapshot.org/#/${space}/proposal/${hash}`,
       title: title ?? space,
     };
   }

--- a/src/helpers/snapshot.ts
+++ b/src/helpers/snapshot.ts
@@ -1,5 +1,9 @@
-import type { OsnapPluginData } from "@/types";
-import { isOsnapProposalPluginData, type SnapshotData } from "@/types";
+import type { PluginTypes } from "@/types";
+import {
+  isOsnapProposalPluginData,
+  isSafeSnapProposalPluginData,
+  type SnapshotData,
+} from "@/types";
 import assert from "assert";
 import useSWR from "swr";
 
@@ -17,11 +21,12 @@ export function useIpfsProposalData(queryText: string | undefined) {
   return useIpfs(explanationRegex ? explanationRegex[1] : undefined);
 }
 
-export function useSnapPluginData(queryText: string | undefined) {
+export function useOsnapPluginData(queryText: string | undefined): PluginTypes {
   const ipfsProposalData = useIpfsProposalData(queryText);
   if (ipfsProposalData?.data) {
-    return getOsnapProposalPluginData(ipfsProposalData.data);
+    return parsePluginData(ipfsProposalData.data);
   }
+  return null;
 }
 
 export function useIpfs(hash?: string) {
@@ -46,13 +51,16 @@ export function snapshotProposalLink(ipfsData: unknown) {
   }
 }
 
-export function getOsnapProposalPluginData(
-  ipfsData: unknown,
-): OsnapPluginData | null {
+export function parsePluginData(ipfsData: unknown): PluginTypes {
   const pluginsData = (ipfsData as SnapshotData)?.data?.message?.plugins;
   if (!pluginsData) return null;
   const parsed = JSON.parse(pluginsData);
-  const isOsnapProposal = isOsnapProposalPluginData(parsed);
-  if (!isOsnapProposal) return null;
-  return parsed;
+
+  if (isOsnapProposalPluginData(parsed)) {
+    return parsed.oSnap;
+  }
+  if (isSafeSnapProposalPluginData(parsed)) {
+    return "safeSnap";
+  }
+  return null;
 }

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -61,13 +61,21 @@ export type OsnapPluginData = {
   };
 };
 
+export type PluginTypes = "safeSnap" | null | OsnapPluginData["oSnap"];
+
+export function isSafeSnapProposalPluginData(proposalData: unknown): boolean {
+  if (typeof proposalData === "object" && proposalData !== null) {
+    return !!(proposalData as Record<"safeSnap", unknown>)?.safeSnap;
+  }
+  return false;
+}
+
 // type guard for checking safe data stored on ipfs by snapshot
 export function isOsnapProposalPluginData(
   proposalData: unknown,
 ): proposalData is OsnapPluginData {
   if (typeof proposalData === "object" && proposalData !== null) {
-    const data = proposalData as OsnapPluginData;
-    const hasOsnapData = !!data?.oSnap?.safe;
+    const hasOsnapData = !!(proposalData as OsnapPluginData)?.oSnap?.safe;
     return hasOsnapData;
   }
   return false;


### PR DESCRIPTION
## motivation

We want to let oSnap users know that they are missing out on Tenderly Sim functionality if they are using the legacy safeSnap plugin.

## screenshots

![Screenshot 2024-04-16 at 16 36 35](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/51655063/990c2e2e-41f7-46c7-b5b0-67679f20b182)
