### PR TITLE
feat: add multiple_choice_query parsing

### DIFF
--- a/src/helpers/queryParsing.ts
+++ b/src/helpers/queryParsing.ts
@@ -193,6 +193,28 @@ export function getQueryMetaData(
       project: "Cozy Finance",
     };
   }
+  if (decodedIdentifier === "MULTIPLE_CHOICE_QUERY") {
+    try {
+      return {
+        ...decodeMultipleChoiceQuery(decodedQueryText),
+        umipUrl:
+          "https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-181.md",
+        umipNumber: "UMIP-181",
+        project: "Unknown",
+      };
+    } catch (err) {
+      console.error("Error parsing multipechoicequery", decodedQueryText, err);
+      return {
+        title: "Multiple Choice query",
+        description: decodedQueryText,
+        umipUrl:
+          "https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-181.md",
+        umipNumber: "UMIP-181",
+        project: "Unknown",
+        proposeOptions: makeSimpleYesOrNoOptions(),
+      };
+    }
+  }
 
   const identifierDetails = approvedIdentifiers[decodedIdentifier];
   const isApprovedIdentifier = Boolean(identifierDetails);
@@ -223,6 +245,62 @@ export function getQueryMetaData(
     umipNumber: undefined,
     proposeOptions: undefined,
     project: "Unknown",
+  };
+}
+
+type MultipleChoiceQuery = {
+  // Require a title string
+  title: string;
+  // The full description of the question, optionally using markdown.
+  description: string;
+  // Optionally specify labels and values for each option a user can select.
+  // If not specified the default is ["no", "yes"], which corresponds to prices ['0','1'] in wei.
+  // numbers must be convertible to a signed int256, and specified as integers in base 10.
+  options?: [label: string, value: string][];
+};
+
+const isMultipleChoicQueryFormat = (
+  input: unknown,
+): input is MultipleChoiceQuery => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const $io0 = (input: any): boolean =>
+    "string" === typeof input?.title && //eslint-disable-line
+    "string" === typeof input?.description && //eslint-disable-line
+    (undefined === input?.options || //eslint-disable-line
+      (Array.isArray(input.options) && //eslint-disable-line
+        input.options.every( //eslint-disable-line
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (elem: any) =>
+            Array.isArray(elem) &&
+            elem.length === 2 &&
+            "string" === typeof elem[0] &&
+            "string" === typeof elem[1],
+        )));
+  return "object" === typeof input && null !== input && $io0(input);
+};
+
+function decodeMultipleChoiceQuery(decodedAncillaryData: string) {
+  const endOfObjectIndex = decodedAncillaryData.lastIndexOf("}");
+  const maybeJson =
+    endOfObjectIndex > 0
+      ? decodedAncillaryData.slice(0, endOfObjectIndex)
+      : decodedAncillaryData;
+  const json = JSON.parse(maybeJson);
+  if (!isMultipleChoicQueryFormat(json))
+    throw new Error("Malformed ancillary data");
+  return {
+    title: json.title,
+    description: json.description,
+    proposeOptions: (
+      json.options ?? [
+        ["No", "0"],
+        ["Yes", "1"],
+      ]
+    ).map((opt: [string, string]) => ({
+      label: opt[0],
+      value: opt[1],
+      secondaryLabel: opt[1],
+    })),
   };
 }
 


### PR DESCRIPTION
## motivation
we want to add umip 181 mutliple choice query support

## changes
adds a decoder and parser to fetch title, descriptiton and options

![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/639b96aa-d1c5-47d2-9097-13120398b6da)

![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/a8f80b66-b392-41cc-9cdf-c1f1dadbae05)

![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/3e63b9e5-91eb-4c34-8431-5e2b34dba8ab)
![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/9875dbe2-ad58-48bb-82d5-b60e6829fdc8)

