### PR TITLE
fix: fix multiple choice values to be proposed as wei

### DIFF
--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -587,7 +587,6 @@ export function useSettlePriceAction({
       disabledReason: "Settling...",
     };
   }
-  // console.log(query)
   // unique to settle, if we have an error preparing the transaction,
   // this means this is probably disputed, but no answer available from dvm yet
   if (prepareSettlePriceError) {


### PR DESCRIPTION
## motivation
currently the UI is treating values specified in mutliple choice options as ETH, so when they are proposed they get converted to wei. this is incorrectly they shoudl be interpreted as wei and not have any scaling.  this is difficult because all values have been assumed to be specified as eth in the app.

## changes
this converts value the user provides to a decimal as eth, so when it gets converted back downstream it properly converts back to the original wei value, ie 5e17 gets converted to .5 as the value, then on proposal this gets converted back to 5e17