### PR TITLE
fix: prevent unbroken strings from overflowing error container

### DIFF
--- a/src/components/Panel/Actions/Errors.tsx
+++ b/src/components/Panel/Actions/Errors.tsx
@@ -15,8 +15,9 @@ export function Errors({ errors }: Props) {
     <>
       {errors.map((message) => (
         <ErrorWrapper key={message}>
-          <Warning />
-          <p className="text-xs sm:text-base text-red-500">
+          <Warning className="shrink-0 h-4 w-4" />
+
+          <p className="text-xs w-full min-w-0 sm:text-base text-red-500 break-words inline-block">
             {sanitizeErrorMessage(message)}
           </p>
         </ErrorWrapper>


### PR DESCRIPTION
## motivation

Any unbroken strings (like addresses) would overflow its container. this is default css.
Here we ensure to break long words to prevent this from happening.