### PR TITLE
Fix show correct result label

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,15 @@
     "comma-dangle": 0,
     "@typescript-eslint/consistent-type-imports": "error",
     "no-inner-declarations": "off",
+    "no-mixed-operators": [
+      "error",
+      {
+        "groups": [
+         ["&&", "||", "??", "?:"]
+      ],
+      "allowSamePrecedence": true
+      }
+    ] ,
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -95,7 +95,7 @@ export function Button({
           {children}
         </_Link>
       ) : null}
-      {type === "button" || type === "submit" ? (
+      {(type === "button" || type === "submit") ? (
         <_Button
           onClick={onClick}
           style={style}

--- a/src/components/LivenessProgressBar.tsx
+++ b/src/components/LivenessProgressBar.tsx
@@ -36,7 +36,7 @@ export function LivenessProgressBar({
   const currentTime = now.getTime();
   const progress = currentTime - startTime;
   const percent = Math.round((progress / totalTime) * 100);
-  const normalizedPercent = percent < 100 && percent >= 0 ? percent : 100;
+  const normalizedPercent = (percent < 100 && percent >= 0) ? percent : 100;
   const timeRemaining = intervalToDuration({
     start: now,
     end: endTimeAsDate,

--- a/src/components/OracleQueryList/ItemDetails.tsx
+++ b/src/components/OracleQueryList/ItemDetails.tsx
@@ -45,8 +45,8 @@ export function ItemDetails({
         <ItemDetailsText>Proposal</ItemDetailsText>
         <ItemDetailsText>{valueToShow}</ItemDetailsText>
       </ItemDetailsInnerWrapper>
-      {livenessEndsMilliseconds !== undefined &&
-      timeMilliseconds !== undefined ? (
+      {(livenessEndsMilliseconds !== undefined &&
+      timeMilliseconds !== undefined) ? (
         <ItemDetailsInnerWrapper>
           <ItemDetailsText>Challenge Period Left</ItemDetailsText>
           <LivenessProgressBar
@@ -61,7 +61,7 @@ export function ItemDetails({
   );
 
   const proposeDetails =
-    hasBond || hasReward ? (
+    (hasBond || hasReward) ? (
       <ItemDetailsWrapper>
         {hasBond && (
           <ItemDetailsInnerWrapper>

--- a/src/components/OracleQueryTable/VerifyCells.tsx
+++ b/src/components/OracleQueryTable/VerifyCells.tsx
@@ -26,9 +26,9 @@ export function VerifyCells({
         </Text>
       </TD>
       {disputeHash && <TD>Disputed</TD>}
-      {!disputeHash &&
+      {(!disputeHash &&
       livenessEndsMilliseconds !== undefined &&
-      timeMilliseconds !== undefined ? (
+      timeMilliseconds !== undefined) ? (
         <TD>
           <LivenessProgressBar
             startTime={timeMilliseconds}

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -439,7 +439,7 @@ function getOOV2SpecificValues(request: Request) {
   const isV2 = isOOV2PriceRequest(request);
   const finalFee = request.finalFee ?? BigInt(0);
   // bond is final fee and bond together
-  const bond = isV2 && request.bond ? request.bond + finalFee : finalFee;
+  const bond = (isV2 && request.bond) ? request.bond + finalFee : finalFee;
   const customLiveness = isV2 ? request.customLiveness : null;
   const eventBased = isV2 ? request.eventBased : null;
 

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -18,7 +18,7 @@ import { isEarlyVote } from "@/constants";
  * @returns a color-mix css color with transparency added
  */
 export function addOpacityToColor(color: string, opacity: number) {
-  const alpha = 100 - opacity * 100;
+  const alpha = 100 - (opacity * 100);
   return `color-mix(in srgb, transparent ${alpha}%, ${color})`;
 }
 
@@ -169,7 +169,7 @@ export function maybeGetValueTextFromOptions(
   valueText: string | null | undefined,
   options: DropdownItem[] | undefined,
 ) {
-  return options?.find(({ value }) => value === valueText)?.label ?? isEarlyVote(valueText) ? "Early Request" : valueText;
+  return  options?.find(({ value }) => value === valueText)?.label ?? (isEarlyVote(valueText) ? "Early Request" : valueText)
 }
 
 /**

--- a/src/hooks/useQueryInSearchParams.ts
+++ b/src/hooks/useQueryInSearchParams.ts
@@ -136,7 +136,7 @@ export function useQueryInSearchParams() {
     const hasMultipleForTx = forTx.length > 1;
 
     const query =
-      hasMultipleForTx && exists(state.eventIndex)
+      (hasMultipleForTx && exists(state.eventIndex))
         ? find<OracleQueryUI>(
             forTx,
             ({

--- a/src/stories/ErrorBanner.stories.tsx
+++ b/src/stories/ErrorBanner.stories.tsx
@@ -79,7 +79,7 @@ function Wrapper({ Component, errorMessages }: Props) {
             addErrorMessage({
               text: errorMessageTextInput,
               link:
-                errorMessageTextInput && errorMessageLinkHrefInput
+                (errorMessageTextInput && errorMessageLinkHrefInput)
                   ? {
                       text: errorMessageLinkTextInput,
                       href: errorMessageLinkHrefInput,


### PR DESCRIPTION
## motivation

This bug was caused because logical operators were being executed in an unexpected order as described in this [Stack Overflow post](https://stackoverflow.com/questions/67575170/operator-precedence-of-nullish-coalescing-and-ternary).
This resulted in the labels for proposals always showing as "Early Request".

This PR, fixes the bug and also adds an eslint rule to prevent possible mistakes when grouping logical operators like this.

## screenshots

Here you can see the correct labels for price requests are being displayed.

<img width="572" alt="Screenshot 2024-04-30 at 08 31 28" src="https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/51655063/a890ef1e-9d08-4057-ae2a-f02bbd9fbb1b">
<img width="569" alt="Screenshot 2024-04-30 at 08 32 23" src="https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/51655063/66ead8af-5941-4d52-8389-6d31b7a2b009">
