### PR TITLE
fix: special case MCQ identifier for parsing values

### DIFF
--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -671,7 +671,22 @@ export function requestToOracleQuery(request: Request): OracleQueryUI {
   if (exists(reward)) {
     result.reward = reward;
   }
-  result.valueText = getPriceRequestValueText(proposedPrice, settlementPrice);
+  // With multiple chocie query, values are specified in WEI unlike other identifiers where they are specified in ETh
+  if (
+    exists(identifier) &&
+    parseIdentifier(identifier) === "MULTIPLE_CHOICE_QUERY"
+  ) {
+    // all our parsing logic assume ether but its not the case for this identifier,
+    // so we need to show this as raw eth with no decimal truncation
+    const price = settlementPrice ?? proposedPrice;
+    if (price === null || price === undefined) {
+      result.valueText = "";
+    } else {
+      result.valueText = ethers.utils.formatEther(price);
+    }
+  } else {
+    result.valueText = getPriceRequestValueText(proposedPrice, settlementPrice);
+  }
 
   if (exists(ancillaryData)) {
     result.queryTextHex = ancillaryData;


### PR DESCRIPTION
## motivation
There is an issue with showing settled values for multiple choice identifier
![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/35939589-7c38-4bb7-93b7-d79db6061f40)
This should show O2, which has a settled value of 1 wei.

## changes
We have to make a special case for the mutliple choice query identifier when calculating value text. 
![image](https://github.com/UMAprotocol/optimistic-oracle-dapp-v2/assets/4429761/23412a44-a32f-402c-869d-a156b379c2ba)
