### PR TITLE
fix: update incomplete event data with direct reads from contract

### DIFF
--- a/libs/src/clients/optimisticOracleV2/client.ts
+++ b/libs/src/clients/optimisticOracleV2/client.ts
@@ -80,7 +80,8 @@ export type Request = RequestKey &
     disputeLogIndex: number;
     settleLogIndex: number;
     requestSettings: RequestSettings;
-  }>;
+  }> &
+  Partial<RequestSettings>;
 
 export interface EventState {
   requests?: Record<string, Request>;
@@ -92,6 +93,7 @@ export function requestId(
   // if enabling sorting, put timestamp first
   return [
     parseIdentifier(request.identifier),
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
     request.timestamp.toString(),
     request.ancillaryData,
   ].join("-");

--- a/libs/src/clients/skinnyOptimisticOracle/client.ts
+++ b/libs/src/clients/skinnyOptimisticOracle/client.ts
@@ -84,6 +84,7 @@ export function requestId(
 ): string {
   // if enabling sorting, put timestamp first
   return [
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
     request.timestamp.toString(),
     request.identifier,
     request.requester,

--- a/shared/types/graphql.ts
+++ b/shared/types/graphql.ts
@@ -410,6 +410,7 @@ export type ParsedOOV1GraphEntity = {
   settlementTimestamp: string | null;
   settlementBlockNumber: string | null;
   settlementLogIndex: string | null;
+  bond: bigint | null | undefined;
 };
 
 export type ParsedOOV2GraphEntity = ParsedOOV1GraphEntity & {

--- a/shared/types/graphql.ts
+++ b/shared/types/graphql.ts
@@ -410,7 +410,6 @@ export type ParsedOOV1GraphEntity = {
   settlementTimestamp: string | null;
   settlementBlockNumber: string | null;
   settlementLogIndex: string | null;
-  bond: bigint | null | undefined;
 };
 
 export type ParsedOOV2GraphEntity = ParsedOOV1GraphEntity & {

--- a/shared/types/oracle.ts
+++ b/shared/types/oracle.ts
@@ -22,6 +22,7 @@ export type Request = {
   ancillaryData: string;
   time: string;
   requester: Address;
+  bond: bigint | null | undefined;
 } & (Partial<ParsedOOV1GraphEntity> | Partial<ParsedOOV2GraphEntity>);
 
 export type Assertion = {

--- a/shared/types/oracle.ts
+++ b/shared/types/oracle.ts
@@ -22,7 +22,7 @@ export type Request = {
   ancillaryData: string;
   time: string;
   requester: Address;
-  bond: bigint | null | undefined;
+  bond?: bigint | null;
 } & (Partial<ParsedOOV1GraphEntity> | Partial<ParsedOOV2GraphEntity>);
 
 export type Assertion = {


### PR DESCRIPTION
fixes UMA-2644

## The bug

When a subgraph is down we resort to fetching request data directly from the chain. We do this first by fetching events from the OO, namely: `RequestPrice` , `ProposePrice`, `DisputePrice` & `Settle`.

For the OOv2 we SUM the bond and finalFee amounts. And when fetching dat like this ONLY rom events, we do not have the bond amount, only the final fee, thus causing teh bug that displays the full bond as only the final fee amount.

This PR ensure that, in the case of a subgraph outage, we first fetch event data, but also get updated data for each request by calling `getRequest()` on the OO.
