### PR TITLE
feat: format cryptic errors when proposing an already proposed request

### DIFF
--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -236,6 +236,9 @@ export function sanitizeErrorMessage(errorMessage: string) {
   if (errorMessage.toLowerCase().includes("cannot estimate gas")) {
     return "Transaction Failed";
   }
+  if (errorMessage.toLowerCase().includes("rejected the request")) {
+    return "Transaction Rejected";
+  }
   if (
     alreadyDisputedV2([new Error(errorMessage)]) ||
     alreadyDisputedV3([new Error(errorMessage)])

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -245,6 +245,12 @@ export function sanitizeErrorMessage(errorMessage: string) {
   if (alreadyProposed([new Error(errorMessage)])) {
     return "Already Proposed";
   }
+  if (
+    alreadySettledV2([new Error(errorMessage)]) ||
+    alreadySettledV3([new Error(errorMessage)])
+  ) {
+    return "Already Settled";
+  }
 
   return errorMessage;
 }
@@ -270,6 +276,14 @@ export function alreadyDisputedV3(errors: (Error | null)[]) {
 
 export function alreadyProposed(errors: (Error | null)[]) {
   return errorsContain(errors, "proposePriceFor: Requested"); // v2
+}
+
+export function alreadySettledV2(errors: (Error | null)[]) {
+  return errorsContain(errors, "_settle: not settleable"); // v2
+}
+
+export function alreadySettledV3(errors: (Error | null)[]) {
+  return errorsContain(errors, "already settled"); // v3
 }
 
 export function cn(...inputs: ClassValue[]) {

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -221,6 +221,7 @@ export function isWagmiAddress(
   if (!maybeAddress) return false;
   return "0x" == maybeAddress.slice(0, 2);
 }
+
 export function assertWagmiAddress(
   maybeAddress: string,
 ): asserts maybeAddress is Address {
@@ -229,13 +230,46 @@ export function assertWagmiAddress(
 }
 
 /**
- * Replaces unhelpful ethereum error/revert message with generic error message string
+ * Replaces cryptic revert or error messages
  */
 export function sanitizeErrorMessage(errorMessage: string) {
-  if (errorMessage.toLocaleLowerCase().includes("cannot estimate gas")) {
+  if (errorMessage.toLowerCase().includes("cannot estimate gas")) {
     return "Transaction Failed";
   }
+  if (
+    alreadyDisputedV2([new Error(errorMessage)]) ||
+    alreadyDisputedV3([new Error(errorMessage)])
+  ) {
+    return "Already Disputed";
+  }
+  if (alreadyProposed([new Error(errorMessage)])) {
+    return "Already Proposed";
+  }
+
   return errorMessage;
+}
+
+export function errorsContain(
+  errors: (Error | null)[],
+  message: string,
+): boolean {
+  return errors.some((e) => {
+    return (
+      e?.message && e.message.toLowerCase().includes(message.toLowerCase())
+    );
+  });
+}
+
+export function alreadyDisputedV2(errors: (Error | null)[]) {
+  return errorsContain(errors, "disputePriceFor: Disputed"); // v2
+}
+
+export function alreadyDisputedV3(errors: (Error | null)[]) {
+  return errorsContain(errors, "already disputed"); // v3
+}
+
+export function alreadyProposed(errors: (Error | null)[]) {
+  return errorsContain(errors, "proposePriceFor: Requested"); // v2
 }
 
 export function cn(...inputs: ClassValue[]) {

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -253,7 +253,7 @@ export function useProposeAction({
   } = usePrepareContractWrite({
     ...proposePriceParams?.(proposePriceInput),
     scopeKey: query?.id,
-    enabled: !!query?.id,
+    enabled: !!query?.id && actionType === "propose",
   });
   const {
     write: proposePrice,
@@ -369,7 +369,7 @@ export function useDisputeAction({
   } = usePrepareContractWrite({
     ...disputePriceParams,
     scopeKey: query?.id,
-    enabled: !!query?.id,
+    enabled: !!query?.id && actionType === "dispute",
   });
   const {
     write: disputePrice,
@@ -451,7 +451,7 @@ export function useDisputeAssertionAction({
 }: {
   query?: OracleQueryUI;
 }): ActionState | undefined {
-  const { disputeAssertionParams, chainId } = query ?? {};
+  const { disputeAssertionParams, chainId, actionType } = query ?? {};
   const { address } = useAccount();
   const {
     config: disputeAssertionConfig,
@@ -461,7 +461,7 @@ export function useDisputeAssertionAction({
   } = usePrepareContractWrite({
     ...disputeAssertionParams?.(address),
     scopeKey: query?.id,
-    enabled: !!query?.id,
+    enabled: !!query?.id && actionType === "dispute",
   });
   const {
     write: disputeAssertion,
@@ -548,7 +548,7 @@ export function useSettlePriceAction({
 }: {
   query?: OracleQueryUI;
 }): ActionState | undefined {
-  const { settlePriceParams, chainId } = query ?? {};
+  const { settlePriceParams, chainId, actionType } = query ?? {};
   const {
     config: settlePriceConfig,
     error: prepareSettlePriceError,
@@ -557,7 +557,7 @@ export function useSettlePriceAction({
   } = usePrepareContractWrite({
     ...settlePriceParams,
     scopeKey: query?.id,
-    enabled: !!query?.id,
+    enabled: !!query?.id && actionType === "settle",
   });
   const {
     write: settlePrice,
@@ -612,9 +612,9 @@ export function useSettlePriceAction({
   }
   if (alreadySettledV2([settlePriceError, prepareSettlePriceError])) {
     return {
-      title: "Already settled",
+      title: "Unable to Settle",
       disabled: true,
-      disabledReason: "Already settled",
+      disabledReason: "Unable to Settle",
     };
   }
   // unique to settle, if we have an error preparing the transaction,
@@ -644,7 +644,7 @@ export function useSettleAssertionAction({
 }: {
   query?: OracleQueryUI;
 }): ActionState | undefined {
-  const { settleAssertionParams, chainId } = query ?? {};
+  const { settleAssertionParams, chainId, actionType } = query ?? {};
   const {
     config: settleAssertionConfig,
     error: prepareSettleAssertionError,
@@ -653,7 +653,7 @@ export function useSettleAssertionAction({
   } = usePrepareContractWrite({
     ...settleAssertionParams,
     scopeKey: query?.id,
-    enabled: !!query?.id,
+    enabled: !!query?.id && actionType === "settle",
   });
   const {
     write: settleAssertion,

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -23,6 +23,8 @@ import {
   alreadyDisputedV2,
   alreadyDisputedV3,
   alreadyProposed,
+  alreadySettledV2,
+  alreadySettledV3,
   handleNotifications,
 } from "@/helpers";
 import { useBalanceAndAllowance } from "@/hooks";
@@ -608,6 +610,13 @@ export function useSettlePriceAction({
       disabledReason: "Settling...",
     };
   }
+  if (alreadySettledV2([settlePriceError, prepareSettlePriceError])) {
+    return {
+      title: "Already settled",
+      disabled: true,
+      disabledReason: "Already settled",
+    };
+  }
   // unique to settle, if we have an error preparing the transaction,
   // this means this is probably disputed, but no answer available from dvm yet
   if (prepareSettlePriceError) {
@@ -695,6 +704,13 @@ export function useSettleAssertionAction({
       title: settling,
       disabled: true,
       disabledReason: "Settling...",
+    };
+  }
+  if (alreadySettledV3([settleAssertionError, prepareSettleAssertionError])) {
+    return {
+      title: "Already settled",
+      disabled: true,
+      disabledReason: "Already settled",
     };
   }
   // unique to settle, if we have an error preparing the transaction,

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -19,7 +19,12 @@ import {
 } from "@/constants";
 // Reinable when we have a good way to convert wagmi logs to ethers logs
 // import { oracleEthersApis } from "@/contexts";
-import { handleNotifications } from "@/helpers";
+import {
+  alreadyDisputedV2,
+  alreadyDisputedV3,
+  alreadyProposed,
+  handleNotifications,
+} from "@/helpers";
 import { useBalanceAndAllowance } from "@/hooks";
 import type { ActionTitle, OracleQueryUI } from "@/types";
 import React, { useEffect } from "react";
@@ -328,6 +333,14 @@ export function useProposeAction({
       return {
         title: proposed,
         disabled: true,
+        disabledReason: "Successfully proposed.",
+      };
+    }
+
+    if (alreadyProposed([prepareProposePriceError, proposePriceError])) {
+      return {
+        title: disputed,
+        disabled: true,
         disabledReason: "Already proposed.",
       };
     }
@@ -401,6 +414,14 @@ export function useDisputeAction({
       title: dispute,
       disabled: true,
       disabledReason: "Preparing dispute transaction...",
+    };
+  }
+
+  if (alreadyDisputedV2([prepareDisputePriceError, disputePriceError])) {
+    return {
+      title: disputed,
+      disabled: true,
+      disabledReason: "Already disputed.",
     };
   }
   if (isDisputePriceLoading || isDisputingPrice) {
@@ -497,12 +518,11 @@ export function useDisputeAssertionAction({
     return {
       title: disputed,
       disabled: true,
-      disabledReason: "Already disputed.",
+      disabledReason: "Successfully disputed.",
     };
   }
   if (
-    prepareDisputeAssertionError?.message &&
-    prepareDisputeAssertionError?.message.includes("already disputed")
+    alreadyDisputedV3([prepareDisputeAssertionError, disputeAssertionError])
   ) {
     return {
       title: disputed,
@@ -510,6 +530,7 @@ export function useDisputeAssertionAction({
       disabledReason: "Already disputed.",
     };
   }
+
   return {
     title: dispute,
     action: disputeAssertion,


### PR DESCRIPTION
closes UMA-2180 UMA-2659

## motivation

The oracle dapp displays some pretty large and unhelpful revert/error messages if a user attempts to propose/dispute/settle any assertions that have already been proposed/dispued/asserted.

This PR ensures we format the revert and error messages both in the tooltip (if button is disabled and preparation for the action failed) as well as in the red error container below the action panel in the case that the preparation succeeded so the user was able to submit a failing transaction.