### PR TITLE
add space name to osnap request titles

### DIFF
--- a/libs/src/utils.ts
+++ b/libs/src/utils.ts
@@ -203,6 +203,12 @@ export function parseIdentifier(identifier: string | null | undefined): string {
   return utf8.replace(/[^\x20-\x7E]+/g, "");
 }
 
+export function extractSnapshotSpace(queryText: string): string | null {
+  const regex = /https:\/\/snapshot\.org\/#\/([a-zA-Z0-9.-]+)\/?/;
+  const match = queryText.match(regex);
+  return match ? match[1] : null;
+}
+
 // This state is meant for adjusting a start/end block when querying events. Some apis will fail if the range
 // is too big, so the following functions will adjust range dynamically.
 export type RangeState = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11812,10 +11812,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^9.0.11:
-  version "9.0.11"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.11.tgz#fc91df4c756050de41b3e478b2158b87c1e79af9"
-  integrity sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==
+husky@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"


### PR DESCRIPTION
## motivation

We want users to be able to find osnap requests easier, at a glance. This PR extracts the space name from the request data and adds it to the title.

<img width="1352" alt="Screenshot 2024-07-19 at 14 04 47" src="https://github.com/user-attachments/assets/aa095304-1931-4892-87ab-f540990a5e6f">
