### PR TITLE
fix: whitelist base sepolia

### DIFF
--- a/shared/constants/oracle.ts
+++ b/shared/constants/oracle.ts
@@ -40,6 +40,7 @@ export const chainsById = {
   416: "SX",
   1116: "Core",
   8453: "Base",
+  84532: "Base Sepolia",
   43114: "Avalanche",
   42161: "Arbitrum",
   80001: "Mumbai",

--- a/src/constants/wallet.ts
+++ b/src/constants/wallet.ts
@@ -16,6 +16,7 @@ import {
   coreDao,
   sepolia,
   base,
+  baseSepolia,
 } from "wagmi/chains";
 
 export const chains = [
@@ -31,6 +32,7 @@ export const chains = [
   coreDao,
   sepolia,
   base,
+  baseSepolia,
   polygonAmoy,
   blast,
 ];


### PR DESCRIPTION
# motivation
we are seeing chain not supported when connected on base sepolia, though we should support it
![image](https://github.com/user-attachments/assets/f37631a2-6e10-49ff-bf0f-cf29529a144f)

# changes
this makes sure the wallet lib knows we are allowing it