### PR TITLE
resolve USDC.e for polygon

### DIFF
--- a/src/components/Currency.tsx
+++ b/src/components/Currency.tsx
@@ -8,6 +8,7 @@ import { FormattedTokenValue } from "./FormattedTokenValue";
 import { LoadingSkeleton } from "./LoadingSkeleton";
 import { makeBlockExplorerLink } from "@shared/utils";
 import { truncateAddress } from "@/helpers";
+import { resolveUsdcSymbol } from "@/constants/tokens";
 
 interface Props {
   address: Address | undefined;
@@ -16,6 +17,7 @@ interface Props {
   showIcon?: boolean;
   showAddressLink?: boolean;
 }
+
 /**
  * Displays a currency icon and amount.
  * If the currency is a known currency, the icon will be displayed.
@@ -34,9 +36,10 @@ export function Currency(props: Props) {
     chainId,
     enabled: !!address && !!chainId,
   });
-  const symbol = token?.symbol;
+  const symbolForDisplay =
+    resolveUsdcSymbol(chainId, token?.address) ?? token?.symbol;
   const decimals = token?.decimals;
-  const Icon = getCurrencyIcon(symbol);
+  const Icon = getCurrencyIcon(token?.symbol);
   const hasIcon = !!Icon && showIcon;
   const isLoading =
     tokenLoading ||
@@ -58,11 +61,11 @@ export function Currency(props: Props) {
             href={`${makeBlockExplorerLink(address, chainId, "address")}`}
             className="border text-sm inline-flex gap-2 items-center border-dashed border-dark/50 hover:border-dark rounded-lg px-1 mr-1"
           >
-            {truncateAddress(address)}
+            {symbolForDisplay}
             {hasIcon ? (
               <Icon className="w-[16px] h-[16px] inline-block" />
             ) : (
-              symbol
+              symbolForDisplay
             )}
           </a>
           <FormattedTokenValue value={value} decimals={decimals} />{" "}
@@ -74,13 +77,13 @@ export function Currency(props: Props) {
       <>
         {hasIcon && <Icon className="w-[16px] h-[16px] inline-block" />}{" "}
         <FormattedTokenValue value={value} decimals={decimals} />{" "}
-        {!hasIcon && symbol}
+        {!hasIcon && symbolForDisplay}
       </>
     );
   }
 
   return (
-    <OuterWrapper hasIcon={hasIcon} symbol={symbol}>
+    <OuterWrapper hasIcon={hasIcon} symbol={truncateAddress(address)}>
       <span
         className="inline-flex items-center gap-2"
         style={{

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -1,0 +1,18 @@
+import type { Address } from "wagmi";
+
+// Add chains as we support bridged usdc
+const USDC_MAP: {
+  [key: number]: Record<Address, string>;
+} = {
+  137: {
+    "0x2791bca1f2de4661ed88a30c99a7a9449aa84174": "USDC.e",
+  },
+};
+
+export function resolveUsdcSymbol(
+  chainId: number | undefined,
+  address: Address | undefined,
+) {
+  if (!chainId || !address) return;
+  return USDC_MAP?.[chainId]?.[address];
+}

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -454,7 +454,6 @@ export function useDisputeAssertionAction({
 }): ActionState | undefined {
   const { disputeAssertionParams, chainId, actionType } = query ?? {};
   const { address } = useAccount();
-  console.log("HERE", disputeAssertionParams?.(address));
   const {
     config: disputeAssertionConfig,
     error: prepareDisputeAssertionError,

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -446,6 +446,7 @@ export function useDisputeAction({
     errors: [prepareDisputePriceError?.message, disputePriceError?.message],
   };
 }
+
 export function useDisputeAssertionAction({
   query,
 }: {
@@ -453,6 +454,7 @@ export function useDisputeAssertionAction({
 }): ActionState | undefined {
   const { disputeAssertionParams, chainId, actionType } = query ?? {};
   const { address } = useAccount();
+  console.log("HERE", disputeAssertionParams?.(address));
   const {
     config: disputeAssertionConfig,
     error: prepareDisputeAssertionError,


### PR DESCRIPTION
closes UMA-2772

- add mapping to resolve bridged usdc symbol (`chainID => tokenAddress => tokenSymbol`)

## screenshots

![Screenshot 2024-09-19 at 17 50 58](https://github.com/user-attachments/assets/c131a30f-e8b2-4db3-bf92-09c8a2efd6bb)
