### PR TITLE
feat: add individual request query for details page

### DIFF
--- a/libs/src/oracle-sdk-v2/client.ts
+++ b/libs/src/oracle-sdk-v2/client.ts
@@ -22,7 +22,6 @@ export function Client(factories: ServiceFactories, handlers: Handlers) {
     });
     handlers.errors && handlers.errors(errors);
   }
-
   // this will be changed eventually, we will need to re-request data
   // on an interval, but it depends on the source of data.
   setTimeout(() => {

--- a/libs/src/oracle-sdk-v2/services/oraclev1/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/ethers/factory.ts
@@ -150,6 +150,7 @@ const ConvertToSharedRequest =
 export type Api = {
   updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
   queryLatestRequests?: (blocksAgo: number) => void;
+  updateFromTransactionHash?: (transactionHash: string) => Promise<void>;
 };
 export const Factory = (config: Config): [ServiceFactory, Api] => {
   const convertToSharedRequest = ConvertToSharedRequest(

--- a/libs/src/oracle-sdk-v2/services/oraclev2/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev2/ethers/factory.ts
@@ -151,6 +151,7 @@ const ConvertToSharedRequest =
 export type Api = {
   updateFromTransactionReceipt: (receipt: TransactionReceipt) => Promise<void>;
   queryLatestRequests?: (blocksAgo: number) => void;
+  updateFromTransactionHash?: (transactionHash: string) => Promise<void>;
 };
 export const Factory = (config: Config): [ServiceFactory, Api] => {
   const convertToSharedRequest = ConvertToSharedRequest(
@@ -173,6 +174,10 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
     } catch (err) {
       console.warn("Error updating oov2 from receipt:", err);
     }
+  }
+  async function updateFromTransactionHash(transactionHash: string) {
+    const receipt = await provider.getTransactionReceipt(transactionHash);
+    await updateFromTransactionReceipt(receipt);
   }
   const service = (handlers: Handlers): Service => {
     if (handlers.requests) events.on("requests", handlers.requests);
@@ -217,6 +222,7 @@ export const Factory = (config: Config): [ServiceFactory, Api] => {
     {
       updateFromTransactionReceipt,
       queryLatestRequests,
+      updateFromTransactionHash,
     },
   ];
 };

--- a/libs/src/oracle-sdk-v2/services/oraclev3/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/ethers/factory.ts
@@ -152,6 +152,7 @@ const ConvertToSharedAssertion =
 export type Api = {
   updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
   queryLatestRequests?: (blocksAgo: number) => void;
+  updateFromTransactionHash?: (transactionHash: string) => Promise<void>;
 };
 export const Factory = (config: Config): [ServiceFactory, Api] => {
   const convertToSharedAssertion = ConvertToSharedAssertion(

--- a/libs/src/oracle-sdk-v2/services/skinnyv1/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/skinnyv1/ethers/factory.ts
@@ -154,6 +154,7 @@ const ConvertToSharedRequest =
 export type Api = {
   updateFromTransactionReceipt: (receipt: TransactionReceipt) => void;
   queryLatestRequests?: (blocksAgo: number) => void;
+  updateFromTransactionHash?: (transactionHash: string) => Promise<void>;
 };
 export const Factory = (config: Config): [ServiceFactory, Api] => {
   const convertToSharedRequest = ConvertToSharedRequest(

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -38,6 +38,8 @@ type EthersServicesList = [
   ServiceFactories,
   Partial<Record<OracleType, Partial<Record<ChainId, Api>>>>,
 ];
+// keep a list we can iterate easily over
+export const oracleEthersApiList: Array<[ChainId, Api]> = [];
 const ethersServicesListInit: EthersServicesList = [[], {}];
 const [oracleEthersServices, oracleEthersApis] = config.providers
   .map((config): [ProviderConfig, ServiceFactory, Api] => {
@@ -55,6 +57,7 @@ const [oracleEthersServices, oracleEthersApis] = config.providers
       result: EthersServicesList,
       [config, service, api],
     ): EthersServicesList => {
+      oracleEthersApiList.push([config.chainId, api]);
       const apiRecords = {
         ...result[1],
         [config.type]: {
@@ -184,7 +187,6 @@ export function OracleDataProvider({ children }: { children: ReactNode }) {
   const [errors, setErrors] = useState<Errors>(
     defaultOracleDataContextState.errors,
   );
-
   useEffect(() => {
     // its important this client only gets initialized once
     Client([...oraclesServices, ...oracleEthersServices], {

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -17,8 +17,6 @@ import {
   settled,
   settling,
 } from "@/constants";
-// Reinable when we have a good way to convert wagmi logs to ethers logs
-// import { oracleEthersApis } from "@/contexts";
 import {
   alreadyDisputedV2,
   alreadyDisputedV3,

--- a/src/hooks/useQueryInSearchParams.ts
+++ b/src/hooks/useQueryInSearchParams.ts
@@ -15,6 +15,7 @@ import { useEffectOnce } from "usehooks-ts";
 import { usePanelContext } from "./contexts";
 import { useQueries } from "./queries";
 import { useUrlBar } from "./useUrlBar";
+import { oracleEthersApiList } from "@/contexts";
 
 function getOracleType(oracleType: string | undefined): OracleType | undefined {
   switch (oracleType) {
@@ -71,11 +72,24 @@ export function useQueryInSearchParams() {
     const hasHash = searchParams?.has("transactionHash");
     const hasEventIndex = searchParams?.has("eventIndex");
 
-    if (hasHash && hasEventIndex) {
-      setState((draft) => {
-        draft.transactionHash = searchParams.get("transactionHash")!;
-        draft.eventIndex = searchParams.get("eventIndex")!;
+    if (hasHash) {
+      const transactionHash = searchParams?.get("transactionHash");
+      oracleEthersApiList.forEach(([, api]) => {
+        api
+          .updateFromTransactionHash?.(transactionHash!)
+          .catch((err) =>
+            console.error(
+              "Error fetching tx by hash in useWueryInSearchParams",
+              err,
+            ),
+          );
       });
+      if (hasEventIndex) {
+        setState((draft) => {
+          draft.transactionHash = transactionHash!;
+          draft.eventIndex = searchParams.get("eventIndex")!;
+        });
+      }
     }
   });
 


### PR DESCRIPTION
# motivation
we want to speed up loading when directed to a single request by tx hash

# changes
this exposes a new function on oov2 ethers services to load something by a tx hash, currently only enabled on oov2 because polymarket needs the most optimization 

# testing
go to settled or proposed tab, choose a really old request, copy url and load it into an incognito window to see how fast it loads the details panel.  try this with the prod site to compare speed