### PR TITLE
fix: hide expiration time if set to 0

### DIFF
--- a/libs/src/oracle-sdk-v2/services/oraclev2/ethers/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev2/ethers/factory.ts
@@ -110,7 +110,7 @@ const ConvertToSharedRequest =
     if (finalFee) result.finalFee = finalFee.toBigInt();
     if (proposer) result.proposer = proposer;
     if (proposedPrice) result.proposedPrice = proposedPrice.toBigInt();
-    if (expirationTime)
+    if (expirationTime && expirationTime.toNumber() > 0)
       result.proposalExpirationTimestamp = expirationTime.toString();
     if (disputer) result.disputer = disputer;
     if (price) result.settlementPrice = price.toBigInt();


### PR DESCRIPTION
# motivation 
highlighted area should not show if not in verify phase
![image](https://github.com/user-attachments/assets/5f26c303-dded-4f16-98fa-466977e3c25f)

# changes
if expiration time is set to 0, leave it undefined in data 
![image](https://github.com/user-attachments/assets/889489ef-421d-4229-b918-39764789aa3f)

