### PR TITLE
fix: go back to single shot load for gql requests

### DIFF
--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/factory.ts
@@ -2,7 +2,7 @@ import type { ChainId, OracleType } from "@shared/types";
 import { parsePriceRequestGraphEntity } from "@shared/utils";
 import type { Address } from "wagmi";
 import type { Handlers, Service, ServiceFactory } from "../../../types";
-import { getPriceRequestsIncremental } from "./queries";
+import { getPriceRequests } from "./queries";
 
 export type Config = {
   url: string;
@@ -15,23 +15,37 @@ export const Factory =
   (config: Config): ServiceFactory =>
   (handlers: Handlers): Service => {
     async function fetch({ url, chainId, address, type }: Config) {
-      for await (const requests of getPriceRequestsIncremental(
-        url,
-        chainId,
-        type,
-      )) {
-        handlers?.requests?.(
-          requests.map((request) =>
-            parsePriceRequestGraphEntity(
-              request,
-              chainId,
-              address as Address,
-              type,
-            ),
+      const requests = await getPriceRequests(url, chainId, type);
+      handlers?.requests?.(
+        requests.map((request) =>
+          parsePriceRequestGraphEntity(
+            request,
+            chainId,
+            address as Address,
+            type,
           ),
-        );
-      }
+        ),
+      );
     }
+    // if we need to bring back incremental loading
+    // async function fetchIncremental({ url, chainId, address, type }: Config) {
+    //   for await (const requests of getPriceRequestsIncremental(
+    //     url,
+    //     chainId,
+    //     type,
+    //   )) {
+    //     handlers?.requests?.(
+    //       requests.map((request) =>
+    //         parsePriceRequestGraphEntity(
+    //           request,
+    //           chainId,
+    //           address as Address,
+    //           type,
+    //         ),
+    //       ),
+    //     );
+    //   }
+    // }
     async function tick() {
       await fetch(config);
     }


### PR DESCRIPTION
# motivation
since introducing incremental loading, pages seem to be really frozen

# changes
this goes back to one shot loading. incremental loading was introduced to speed up landing on specific requests, but this was fixed with a more targeted change, so we can try to go back to how we were loading before, which was buffer everything then render when done, vs incrementally rendering in batches