### PR TITLE
fix: improve weights url search scorer

### DIFF
--- a/src/hooks/useQueryInSearchParams.ts
+++ b/src/hooks/useQueryInSearchParams.ts
@@ -157,7 +157,7 @@ export function useQueryInSearchParams() {
     // adding this because sometimes event indexes are not exact
     function eventDistanceScore(value: number, target: number) {
       const distance = Math.abs(value - target);
-      if (distance === 0) return 0;
+      if (distance === 0) return 4;
       const maxDistance = Math.max(distance, 10);
       return -(maxDistance / 10);
     }


### PR DESCRIPTION
# motiviation
we are still colliding with some request urls

# changes
we scale the event log score according the the transaction match type. sorry this is a bit opaque, but it seems to solve the issue for now