### PR TITLE
fix

### DIFF
--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -37,7 +37,7 @@ import { upperCase } from "lodash";
 import type { Address } from "wagmi";
 import { erc20ABI } from "wagmi";
 import { formatBytes32String } from "./ethers";
-import { getQueryMetaData } from "./queryParsing";
+import { getQueryMetaData, parseAncillaryJson } from "./queryParsing";
 import { isUnresolvable } from "./validators";
 import type { Infer } from "superstruct";
 import { object, string, validate } from "superstruct";
@@ -117,10 +117,11 @@ const OracleDetailsSchema = object({
 type OracleDetailsSchemaT = Infer<typeof OracleDetailsSchema>;
 
 function maybeExtractJsonFields(
-  maybeJson: string,
+  decodedAncillaryData: string,
 ): OracleDetailsSchemaT | undefined {
   try {
-    const [error, data] = validate(JSON.parse(maybeJson), OracleDetailsSchema);
+    const maybeJson = parseAncillaryJson(decodedAncillaryData);
+    const [error, data] = validate(maybeJson, OracleDetailsSchema);
 
     return error
       ? undefined

--- a/src/helpers/queryParsing.ts
+++ b/src/helpers/queryParsing.ts
@@ -1005,7 +1005,8 @@ export function parseAncillaryJson(
     const parsed = JSON.parse(sanitizedJSON);
     return parsed as Record<string, unknown>;
   } catch (error) {
-    throw new Error("Failed to parse JSON after sanitation", { cause: error });
+    console.error("Failed to parse JSON after sanitation", error);
+    return;
   }
 }
 


### PR DESCRIPTION
## motivation

Some requests are formatted incorrectly, double quotes inside a json value are not always escaped correctly, thus we cannot parse it. 
This PR adds a utility function that will attempt to find unescaped quotes and escape them, then parse the result.