### PR TITLE
improve: set limit on settled page requests

### DIFF
--- a/src/components/Header/Title.tsx
+++ b/src/components/Header/Title.tsx
@@ -47,7 +47,7 @@ export function Title({ page }: { page: PageName }) {
       <TextWrapper>
         <TitleText>{pageTitle}</TitleText>
         {page === "settled" && (
-          <SubTitle>Historical UMA oracle requests</SubTitle>
+          <SubTitle>Recently settled UMA oracle requests</SubTitle>
         )}
       </TextWrapper>
     </Wrapper>

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -140,6 +140,7 @@ const Env = ss.object({
   NEXT_PUBLIC_PROVIDER_V2_8453: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_V3_8453: ss.optional(ss.string()),
   NEXT_PUBLIC_PROVIDER_SKINNY_8453: ss.optional(ss.string()),
+  NEXT_PUBLIC_MAX_SETTLED_REQUESTS: ss.optional(ss.string()),
 });
 export type Env = ss.Infer<typeof Env>;
 
@@ -308,6 +309,8 @@ const env = ss.create(
     NEXT_PUBLIC_SUBGRAPH_V3_8453: process.env.NEXT_PUBLIC_SUBGRAPH_V3_8453,
     NEXT_PUBLIC_SUBGRAPH_SKINNY_8453:
       process.env.NEXT_PUBLIC_SUBGRAPH_SKINNY_8453,
+    NEXT_PUBLIC_MAX_SETTLED_REQUESTS:
+      process.env.NEXT_PUBLIC_MAX_SETTLED_REQUESTS,
   },
   Env,
 );
@@ -359,6 +362,7 @@ const Config = ss.object({
   defaultLiveness: ss.string(),
   subgraphs: SubgraphConfigs,
   providers: ProviderConfigs,
+  maxSettledRequests: ss.string(),
 });
 export type Config = ss.Infer<typeof Config>;
 
@@ -447,6 +451,7 @@ function parseEnv(env: Env): Config {
     defaultLiveness: env.NEXT_PUBLIC_DEFAULT_LIVENESS ?? "7600",
     subgraphs,
     providers,
+    maxSettledRequests: env.NEXT_PUBLIC_MAX_SETTLED_REQUESTS ?? "5000",
   };
 }
 

--- a/src/contexts/OracleDataContext.tsx
+++ b/src/contexts/OracleDataContext.tsx
@@ -32,6 +32,7 @@ import unionWith from "lodash/unionWith";
 import type { ReactNode } from "react";
 import { createContext, useEffect, useReducer, useState } from "react";
 
+const maxSettledRequests = Number(config.maxSettledRequests);
 //TODO: hate this approach, will need to refactor in future, current services interface does not make it easy to define custom functions
 // this will be moved somewhere else in future pr.
 type EthersServicesList = [
@@ -153,10 +154,14 @@ function DataReducerFactory<Input extends Request | Assertion>(
       return result;
     }, init);
 
+    const sorted = sortQueries(queries);
     return {
       ...state,
       all: { ...all },
-      ...sortQueries(queries),
+      verify: sorted.verify,
+      propose: sorted.propose,
+      // limit settled length. this is adjustable through env but defaults to 5k if not specified
+      settled: sorted.settled.slice(0, maxSettledRequests),
     };
   };
 }

--- a/src/hooks/queries.ts
+++ b/src/hooks/queries.ts
@@ -3,16 +3,9 @@ import { useOracleDataContext, usePageContext } from "./contexts";
 
 export function useQueries() {
   const { page } = usePageContext();
-  const { verify = [], propose = [], settled = [] } = useOracleDataContext();
-  const forPages = { verify, propose, settled };
-  const all = useMemo(
-    () => [...verify, ...propose, ...settled],
-    [propose, settled, verify],
-  );
-
-  const forCurrentPage = forPages[page];
-
-  return useMemo(() => ({ all, forCurrentPage }), [all, forCurrentPage]);
+  const state = useOracleDataContext();
+  const forCurrentPage = state[page] ?? [];
+  return { forCurrentPage, all: Object.values(state?.all ?? {}) };
 }
 
 export function useQueryById(id: string | undefined) {


### PR DESCRIPTION
# motivation
improve loading speed of settled page

# changes
this limits lookback to 5k settled requests which significantly speeds up loading

test a specific request wiht this query from 2022: 
`/settled?transactionHash=0x25fa9cc18c2ff800776a7e037ce6a332901dfc30add06f2bb1e6640f3a378c35&eventIndex=5`