### PR TITLE
do not round when scaling proposed prices

### DIFF
--- a/shared/utils/ethers.ts
+++ b/shared/utils/ethers.ts
@@ -64,15 +64,26 @@ export const commify = ethers.utils.commify;
  * @param number - the number to format
  * @param options.decimals - the number of decimals to truncate to, defaults to 2
  * @param options.isFormatEther - whether to format the number as ether, defaults to false
+ * @param options.strict - whether to return the full number without truncation, defaults to false
  * @returns the formatted number
  */
 export function formatNumberForDisplay(
   number: bigint | string | undefined,
-  options?: { decimals?: number; isFormatEther?: boolean },
+  options?: { decimals?: number; isFormatEther?: boolean; strict?: boolean },
 ) {
   if (!number) return "0";
-  const { decimals = 2, isFormatEther = false } = options || {};
-  const _number = isFormatEther ? formatEther(number) : number.toString();
+  const { decimals = 2, isFormatEther = false, strict = false } = options || {};
+
+  // Convert BigInt to string with proper scaling
+  const _number = isFormatEther
+    ? formatEther(number.toString())
+    : number.toString();
+
+  // If strict mode is enabled, return the full number without any truncation
+  if (strict) {
+    return commify(_number);
+  }
+
   return truncateDecimals(commify(_number), decimals);
 }
 

--- a/shared/utils/ethers.ts
+++ b/shared/utils/ethers.ts
@@ -64,26 +64,15 @@ export const commify = ethers.utils.commify;
  * @param number - the number to format
  * @param options.decimals - the number of decimals to truncate to, defaults to 2
  * @param options.isFormatEther - whether to format the number as ether, defaults to false
- * @param options.strict - whether to return the full number without truncation, defaults to false
  * @returns the formatted number
  */
 export function formatNumberForDisplay(
   number: bigint | string | undefined,
-  options?: { decimals?: number; isFormatEther?: boolean; strict?: boolean },
+  options?: { decimals?: number; isFormatEther?: boolean },
 ) {
   if (!number) return "0";
-  const { decimals = 2, isFormatEther = false, strict = false } = options || {};
-
-  // Convert BigInt to string with proper scaling
-  const _number = isFormatEther
-    ? formatEther(number.toString())
-    : number.toString();
-
-  // If strict mode is enabled, return the full number without any truncation
-  if (strict) {
-    return commify(_number);
-  }
-
+  const { decimals = 2, isFormatEther = false } = options || {};
+  const _number = isFormatEther ? formatEther(number) : number.toString();
   return truncateDecimals(commify(_number), decimals);
 }
 

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -192,7 +192,7 @@ function getPriceRequestValueText(
 ) {
   const price = settlementPrice ?? proposedPrice;
   if (price === null || price === undefined) return null;
-  return formatNumberForDisplay(price, { isFormatEther: true, strict: true });
+  return formatNumberForDisplay(price, { isFormatEther: true });
 }
 
 function isOOV1PriceRequest(

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -192,7 +192,7 @@ function getPriceRequestValueText(
 ) {
   const price = settlementPrice ?? proposedPrice;
   if (price === null || price === undefined) return null;
-  return formatNumberForDisplay(price, { isFormatEther: true });
+  return formatNumberForDisplay(price, { isFormatEther: true, decimals: 18 });
 }
 
 function isOOV1PriceRequest(

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -192,7 +192,7 @@ function getPriceRequestValueText(
 ) {
   const price = settlementPrice ?? proposedPrice;
   if (price === null || price === undefined) return null;
-  return formatNumberForDisplay(price, { isFormatEther: true });
+  return formatNumberForDisplay(price, { isFormatEther: true, strict: true });
 }
 
 function isOOV1PriceRequest(


### PR DESCRIPTION
Fix: Preserve Exact Precision for Proposal Price Display

## Problem
When displaying unscaled proposal prices (e.g., `1` which should be `1000000000000000000` in wei), the UI was incorrectly truncating decimals during the display formatting process. This caused issues when trying to match prices against ancillary data, as the exact precision was being lost.

## Changes
- Retain 18 decimals of precision when scaling price.

## Testing
Incorrect display [OO Proposal](https://oracle.uma.xyz/?transactionHash=0xae7354ab83366edf0dbe231607ce6095b8b80f1b539058833574eade370654c2&chainId=137&oracleType=OptimisticV2&eventIndex=141)
Correct Display [OO Proposal](https://optimistic-oracle-dapp-v2-git-fix-do-not-truncate-in-ce1c3b-uma.vercel.app/?transactionHash=0xae7354ab83366edf0dbe231607ce6095b8b80f1b539058833574eade370654c2&chainId=137&oracleType=OptimisticV2&eventIndex=141)