### PR TITLE
Feat numerical

### DIFF
--- a/src/hooks/proposePriceInput.ts
+++ b/src/hooks/proposePriceInput.ts
@@ -27,6 +27,7 @@ function useSinglePriceInput({ proposeOptions }: OracleQueryUI) {
   function onSelect(item: DropdownItem) {
     if (item.value === "custom") {
       setIsCustomInput(true);
+      setProposePriceInput("");
     } else {
       setProposePriceInput((item.value ?? "").toString());
     }

--- a/src/identifiers/Numerical.ts
+++ b/src/identifiers/Numerical.ts
@@ -1,0 +1,53 @@
+import type { DropdownItem } from "@/types";
+import type { MetaData } from "./abstract";
+import { Identifier } from "./abstract";
+import { getTitleAndDescriptionFromTokens } from "@/helpers/queryParsing";
+
+export class Numerical extends Identifier {
+  constructor() {
+    super({
+      name: "NUMERICAL",
+      umipNumber: 165,
+    });
+  }
+
+  getMetaData(decodedAncillaryData: string): MetaData {
+    // According to the NUMERICAL identifier spec, the title should be inserted after "q:".
+    // However, some integrators follow the YES_OR_NO_QUERY standard which uses "title:" and "description:".
+    // Therefore, we check for both formats.
+    const { title, description } =
+      getTitleAndDescriptionFromTokens(decodedAncillaryData);
+    const { title: titleFromQ } = getTitleAndDescriptionFromTokens(
+      decodedAncillaryData,
+      "q:",
+    );
+
+    return {
+      title: title ?? titleFromQ ?? this.name,
+      description: description ?? title ?? decodedAncillaryData,
+      umipUrl: this.umipUrl,
+      umipNumber: this.umipNumber,
+    };
+  }
+
+  parseQuery(decodedAncillaryData: string) {
+    return {
+      ...this.getMetaData(decodedAncillaryData),
+      proposeOptions: this.makeProposeOptions(),
+    };
+  }
+
+  makeDefaultProposeOptions(): DropdownItem[] {
+    return [
+      { label: "Unresolvable", value: "0.5", secondaryLabel: "Unresolvable" },
+      {
+        label: "Custom",
+        value: "custom",
+      },
+    ];
+  }
+
+  makeProposeOptions(): DropdownItem[] {
+    return this.makeDefaultProposeOptions();
+  }
+}

--- a/src/identifiers/YesOrNoQuery.ts
+++ b/src/identifiers/YesOrNoQuery.ts
@@ -34,6 +34,15 @@ export class YesOrNoQuery extends Identifier {
     return [
       { label: "Yes", value: "1", secondaryLabel: "1" },
       { label: "No", value: "0", secondaryLabel: "0" },
+      {
+        label: "Custom",
+        value: "custom",
+      },
+      {
+        label: "Unknown",
+        value: "0.5",
+        secondaryLabel: "50/50",
+      },
     ];
   }
 

--- a/src/identifiers/index.ts
+++ b/src/identifiers/index.ts
@@ -8,6 +8,7 @@ import { MultipleChoiceQuery } from "./MultipleChoiceQuery";
 import { MultipleValues } from "./MultipleValues";
 import { RopuEthx } from "./RopuEthx";
 import { Numerical } from "./Numerical";
+import { getTitleAndDescriptionFromTokens } from "@/helpers/queryParsing";
 
 // Default identifier for handling approved identifiers without specific implementations
 export class ApprovedIdentifier extends Identifier {
@@ -82,9 +83,12 @@ export class UnknownIdentifier extends Identifier {
   }
 
   getMetaData(_decodedAncillaryData: string): MetaData {
+    const { title, description } = getTitleAndDescriptionFromTokens(
+      _decodedAncillaryData,
+    );
     return {
-      title: this.name,
-      description: "No description found for this request.",
+      title: title ?? this.name,
+      description: description ?? _decodedAncillaryData,
       umipUrl: this.umipUrl,
       umipNumber: this.umipNumber,
     };

--- a/src/identifiers/index.ts
+++ b/src/identifiers/index.ts
@@ -7,6 +7,7 @@ import { AcrossV2 } from "./AcrossV2";
 import { MultipleChoiceQuery } from "./MultipleChoiceQuery";
 import { MultipleValues } from "./MultipleValues";
 import { RopuEthx } from "./RopuEthx";
+import { Numerical } from "./Numerical";
 
 // Default identifier for handling approved identifiers without specific implementations
 export class ApprovedIdentifier extends Identifier {
@@ -58,6 +59,10 @@ export class ApprovedIdentifier extends Identifier {
     return [
       { label: "Yes", value: "1", secondaryLabel: "1" },
       { label: "No", value: "0", secondaryLabel: "0" },
+      {
+        label: "Custom",
+        value: "custom",
+      },
     ];
   }
 
@@ -97,6 +102,10 @@ export class UnknownIdentifier extends Identifier {
     return [
       { label: "Yes", value: "1", secondaryLabel: "1" },
       { label: "No", value: "0", secondaryLabel: "0" },
+      {
+        label: "Custom",
+        value: "custom",
+      },
     ];
   }
 
@@ -108,7 +117,6 @@ export class UnknownIdentifier extends Identifier {
 class IdentifierRegistry {
   private static instance: IdentifierRegistry;
   private identifiers: Map<string, Identifier>;
-  //   private approvedIdentifiers: Record<string, IdentifierDetails>;
 
   private constructor() {
     this.identifiers = new Map();
@@ -122,6 +130,7 @@ class IdentifierRegistry {
       new MultipleValues(),
       new RopuEthx(),
       new AcrossV2(),
+      new Numerical(),
       // Add more here
     ];
 


### PR DESCRIPTION
closes UMA-2905
# NUMERICAL Identifier Support 

## Primary Changes
### NUMERICAL Identifier Support
- Added custom parsing logic for `NUMERICAL` identifiers
- Implemented logic to parse ancillary data
- Added functionality to generate propose options for requests

### YES_OR_NO_QUERY Improvements
- Added new options to the YES_OR_NO_QUERY identifier:
  - Unknown (50/50) option
  - Custom input option
- Updated default fallback propose options for cases when a request's identifier is not found in approved identifiers list

## UX Improvements
- Fixed input handling: Propose price value now clears when switching from dropdown to custom input mode

## Testing
These are the same request. 
- Current [Numerical request](https://oracle.uma.xyz/?transactionHash=0x45ced4fcb7226e5da1eeca10b536f5019939489952f92e5b41a6bfe6dddb9777&eventIndex=106)
- Improved [Numerical request](https://optimistic-oracle-dapp-v2-git-feat-numerical-uma.vercel.app/?transactionHash=0x45ced4fcb7226e5da1eeca10b536f5019939489952f92e5b41a6bfe6dddb9777&eventIndex=106)

Things that should be fixed:
- show UMIP number and URL in details panel.
- Parse and display title.
- Show proposed price as numerical value
