### PR TITLE
Add Polymerket requester address

### DIFF
--- a/src/components/Panel/Title.tsx
+++ b/src/components/Panel/Title.tsx
@@ -21,7 +21,7 @@ export function Title({ project, title, isLoading, close }: Props) {
   const iconStyles =
     "min-w-[1.25rem] flex items-center justify-center w-[clamp(1.25rem,0.8rem+2vw,2.5rem)] h-[clamp(1.25rem,0.8rem+2vw,2.5rem)]";
   return (
-    <div className="grid grid-cols-[auto,1fr,auto] gap-page-padding min-h-[84px] px-page-padding lg:px-7 py-5 bg-blue-grey-700">
+    <div className="grid grid-cols-[auto,1fr,auto] content-center gap-page-padding min-h-[84px] px-page-padding lg:px-7 py-5 bg-blue-grey-700">
       {isLoading ? (
         <div className={iconStyles}>
           <LoadingSkeleton width="100%" height="100%" borderRadius="50%" />

--- a/src/projects/abstract.ts
+++ b/src/projects/abstract.ts
@@ -96,14 +96,14 @@ export abstract class Project<T extends string> {
     );
   }
 
-  isRequester(requester: string): boolean {
+  isRequester(requester: string | undefined): boolean {
     if (!requester || !this.requesters?.length) return false;
     return this.requesters.some(
       (addr) => addr.toLowerCase() === requester.toLowerCase(),
     );
   }
 
-  isInitializer(initializer: string): boolean {
+  isInitializer(initializer: string | undefined): boolean {
     if (!initializer || !this.initializers?.length) return false;
     return this.initializers.some(
       (addr) => addr.toLowerCase() === initializer.toLowerCase(),
@@ -120,7 +120,7 @@ export abstract class Project<T extends string> {
     const { requester, decodedIdentifier, decodedAncillaryData } = params;
 
     // If no parameters provided, we can't validate
-    if (!requester && !decodedIdentifier && !decodedAncillaryData) {
+    if (!requester || !decodedIdentifier || !decodedAncillaryData) {
       return false;
     }
 
@@ -129,13 +129,18 @@ export abstract class Project<T extends string> {
       return true;
     }
 
-    // Can't validate
+    // if from project-controlled EOA, match immediately
+    if (this.isInitializer(getInitializerAddress(decodedAncillaryData))) {
+      return true;
+    }
+
     if (
       !this.requesters?.length &&
       !this.requiredTokens &&
       !this.identifiers?.length &&
       !this.initializers?.length
     ) {
+      // Can't validate
       return false;
     }
 

--- a/src/projects/polymarket.ts
+++ b/src/projects/polymarket.ts
@@ -27,6 +27,7 @@ export class PolymarketProject extends Project<"Polymarket"> {
         "0x2f5e3684cb1f318ec51b00edba38d79ac2c0aa9d", // Polymarket CTF Adapter Address V2
         "0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e", // Polymarket CTF Exchange Address
         "0xb21182d0494521cf45dbbeebb5a3acaab6d22093", // Polymarket Sports Address
+        "0x157ce2d672854c848c9b79c49a8cc6cc89176a49", // Polymarket CTF Adapter Address V3
       ],
       requiredTokens: {
         YES_OR_NO_QUERY: ["q: title:", "res_data:"],


### PR DESCRIPTION
closes UMA-2912

## Changes
1. Adds Polymarket's [UmaCTFAdapter](0x157Ce2d672854c848c9b79C49a8Cc6cc89176a49) contract as requester address.
2. When matching a request to a project, if we match an initialzier address, then match the project to the request without performing other checks