### PR TITLE
append calldata with tracker

### DIFF
--- a/src/constants/siteMetaData.ts
+++ b/src/constants/siteMetaData.ts
@@ -3,3 +3,5 @@ export const title = "Optimistic Oracle V2 | UMA";
 export const description = "An optimistic oracle built for web3";
 
 export const images = "/assets/twitter-card.png";
+
+export const trackingCalldataSuffix = "0xfe0000";

--- a/src/hooks/actions.tsx
+++ b/src/hooks/actions.tsx
@@ -16,6 +16,7 @@ import {
   settle,
   settled,
   settling,
+  trackingCalldataSuffix,
 } from "@/constants";
 import {
   alreadyDisputedV2,
@@ -278,6 +279,7 @@ export function useProposeAction({
     ...proposePriceParams?.(proposePriceInput),
     scopeKey: query?.id,
     enabled: prepare && !!query?.id && actionType === "propose",
+    dataSuffix: trackingCalldataSuffix,
   });
   const {
     write: proposePrice,
@@ -407,6 +409,7 @@ export function useDisputeAction({
     ...disputePriceParams,
     scopeKey: query?.id,
     enabled: prepare && !!query?.id && actionType === "dispute",
+    dataSuffix: trackingCalldataSuffix,
   });
   const {
     write: disputePrice,
@@ -502,6 +505,7 @@ export function useDisputeAssertionAction({
     ...disputeAssertionParams?.(address),
     scopeKey: query?.id,
     enabled: prepare && !!query?.id && actionType === "dispute",
+    dataSuffix: trackingCalldataSuffix,
   });
   const {
     write: disputeAssertion,


### PR DESCRIPTION
closes UMA-2904
## Changes
Append hex value `0xfe0000` to calldata for:
- Propose
- Dispute request
- DIspute assertion

## Testing
- [x] Is tested?
Can confirm transactions don't revert and hex value is appended

<img width="1347" height="600" alt="Screenshot 2025-07-22 at 09 18 46" src="https://github.com/user-attachments/assets/30064027-c2af-48f6-85fa-939f37cce010" />
