### PR TITLE
chore: remove custom liveness and bond entity queries

### DIFF
--- a/libs/src/oracle-sdk-v2/services/managedv2/gql/factory.ts
+++ b/libs/src/oracle-sdk-v2/services/managedv2/gql/factory.ts
@@ -23,35 +23,6 @@ export const Factory =
             chainId,
             type,
           )) as OOV2GraphEntity[];
-
-          // const enhancedRequests = await Promise.all(
-          //   requests.map(async (request) => {
-          //     const [customBond, customLiveness] = await Promise.all([
-          //       getCustomBondForRequest(
-          //         url,
-          //         request.requester,
-          //         request.identifier,
-          //         request.ancillaryData,
-          //       ),
-          //       getCustomLivenessForRequest(
-          //         url,
-          //         request.requester,
-          //         request.identifier,
-          //         request.ancillaryData,
-          //       ),
-          //     ]);
-          //     const enhancedRequest = {
-          //       ...request,
-          //       customLiveness: customLiveness?.customLiveness?.toString(),
-          //       bond: customBond?.customBond
-          //         ? customBond.customBond
-          //         : request.bond,
-          //     };
-
-          //     return enhancedRequest;
-          //   }),
-          // );
-
           handlers.requests?.(
             requests.map((request) =>
               parsePriceRequestGraphEntity(

--- a/libs/src/oracle-sdk-v2/services/managedv2/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/managedv2/gql/queries.ts
@@ -5,8 +5,6 @@ import type {
   OOV2GraphEntity,
   OracleType,
   PriceRequestsQuery,
-  CustomBond,
-  CustomLiveness,
 } from "@shared/types";
 import { makeQueryName } from "@shared/utils";
 import request, { gql } from "graphql-request";
@@ -113,64 +111,6 @@ async function fetchAllRequests(
   result.push(...requests);
 
   return result;
-}
-
-export async function getCustomBondForRequest(
-  url: string,
-  requester: string,
-  identifier: string,
-  ancillaryData: string,
-) {
-  const query = gql`
-    query GetCustomBond {
-      customBonds(where: { requester: "${requester}", identifier: "${identifier}", ancillaryData: "${ancillaryData}" }) {
-        id
-        requester
-        identifier
-        ancillaryData
-        customBond
-      }
-    }
-  `;
-
-  const result = await request<
-    { customBonds: CustomBond[] } | { errors: { message: string }[] }
-  >(url, query);
-
-  if ("errors" in result) {
-    throw new Error(result.errors[0].message);
-  }
-
-  return result?.customBonds?.[0] || null;
-}
-
-export async function getCustomLivenessForRequest(
-  url: string,
-  requester: string,
-  identifier: string,
-  ancillaryData: string,
-) {
-  const query = gql`
-    query GetCustomLiveness {
-      customLivenesses(where: { requester: "${requester}", identifier: "${identifier}", ancillaryData: "${ancillaryData}" }) {
-        id
-        requester
-        identifier
-        ancillaryData
-        customLiveness
-      }
-    }
-  `;
-
-  const result = await request<
-    { customLiveness: CustomLiveness[] } | { errors: { message: string }[] }
-  >(url, query);
-
-  if ("errors" in result) {
-    throw new Error(result.errors[0].message);
-  }
-
-  return result?.customLiveness?.[0] || null;
 }
 
 async function fetchPriceRequests(url: string, query: string) {

--- a/shared/types/graphql.ts
+++ b/shared/types/graphql.ts
@@ -421,19 +421,3 @@ export type ParsedOOV2GraphEntity = ParsedOOV1GraphEntity & {
 export type ParsedOOV3GraphEntity = ReturnType<
   typeof parseAssertionGraphEntity
 >;
-
-export type CustomBond = {
-  id: string;
-  requester: string;
-  identifier: string;
-  ancillaryData: string;
-  customBond: number;
-};
-
-export type CustomLiveness = {
-  id: string;
-  requester: string;
-  identifier: string;
-  ancillaryData: string;
-  customLiveness: number;
-};

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -775,24 +775,7 @@ export function requestToOracleQuery(request: Request): OracleQueryUI {
     result.expiryType = eventBased ? "Event-based" : "Time-based";
   }
 
-  // For managed OO v2, calculate liveness end time using customLiveness and proposalTimestamp
-  if (
-    request.oracleType === "Managed Optimistic Oracle V2" &&
-    exists(customLiveness) &&
-    exists(proposalTimestamp)
-  ) {
-    const proposalTime = Number(proposalTimestamp);
-    const livenessDuration = Number(customLiveness);
-    const livenessEndTime = proposalTime + livenessDuration;
-
-    result.livenessEndsMilliseconds = toTimeMilliseconds(
-      livenessEndTime.toString(),
-    );
-    result.formattedLivenessEndsIn = toTimeFormatted(
-      livenessEndTime.toString(),
-    );
-  } else if (exists(proposalExpirationTimestamp)) {
-    // For other oracle types, use the existing logic
+  if (exists(proposalExpirationTimestamp)) {
     result.livenessEndsMilliseconds = getLivenessEnds(
       proposalExpirationTimestamp,
     );


### PR DESCRIPTION
depends on https://github.com/UMAprotocol/subgraphs/pull/103
closes UMA-2936

## Motivation
We no longer need to query `CustomLiveness` and `CustomBond` entities separately for each request.
The `bond`, `currency` and `customLiveness` values are set directly on the `PRiceRequest` entity.
This PR removes this now obsolete logic.