### PR TITLE
fix: calculate liveness

### DIFF
--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -776,7 +776,6 @@ export function requestToOracleQuery(request: Request): OracleQueryUI {
   }
 
   if (exists(proposalExpirationTimestamp)) {
-    // For other oracle types, use the existing logic
     result.livenessEndsMilliseconds = getLivenessEnds(
       proposalExpirationTimestamp,
     );


### PR DESCRIPTION
Use the `proposalExpirationTimestamp` already calculated by the Managed OO