### PR TITLE
feat(liveness): show Challenge Period Extended for managed OOV2 after 5-min grace period

### DIFF
--- a/src/components/LivenessProgressBar.tsx
+++ b/src/components/LivenessProgressBar.tsx
@@ -13,6 +13,8 @@ interface Props {
   fontSize?: number;
   marginBottom?: number;
   endedLabel?: string;
+  gracePeriodMs?: number;
+  gracePeriodLabel?: string;
 }
 /**
  * A progress bar that shows the time remaining until a request or assertion
@@ -26,6 +28,8 @@ export function LivenessProgressBar({
   fontSize,
   marginBottom,
   endedLabel = "Ended",
+  gracePeriodMs,
+  gracePeriodLabel,
 }: Props) {
   const [now, setNow] = useState(new Date());
 
@@ -54,6 +58,24 @@ export function LivenessProgressBar({
 
   const isEnded = endTimeAsDate < now;
 
+  const graceDeadline =
+    gracePeriodMs !== undefined ? endTime + gracePeriodMs : undefined;
+  const isInGracePeriod =
+    isEnded && graceDeadline !== undefined && currentTime < graceDeadline;
+  const isAfterGracePeriod =
+    isEnded && graceDeadline !== undefined && currentTime >= graceDeadline;
+
+  let displayText: string;
+  if (!isEnded) {
+    displayText = timeRemainingString;
+  } else if (isInGracePeriod) {
+    displayText = "0 m 00 s";
+  } else if (isAfterGracePeriod && gracePeriodLabel) {
+    displayText = gracePeriodLabel;
+  } else {
+    displayText = endedLabel;
+  }
+
   const isTextRed =
     !timeRemaining.hours || timeRemaining.hours === 0 || isEnded;
 
@@ -69,7 +91,7 @@ export function LivenessProgressBar({
           } as CSSProperties
         }
       >
-        {isEnded ? endedLabel : timeRemainingString}
+        {displayText}
       </Text>
       <_Root value={normalizedPercent}>
         <_Indicator

--- a/src/components/OracleQueryList/ItemDetails.tsx
+++ b/src/components/OracleQueryList/ItemDetails.tsx
@@ -68,6 +68,10 @@ export function ItemDetails({
             fontSize={12}
             marginBottom={0}
             endedLabel={isManaged ? "Awaiting Settlement" : undefined}
+            gracePeriodMs={isManaged ? 5 * 60 * 1000 : undefined}
+            gracePeriodLabel={
+              isManaged ? "Challenge Period Extended" : undefined
+            }
           />
         </ItemDetailsInnerWrapper>
       ) : undefined}

--- a/src/components/OracleQueryList/LoadingItem.tsx
+++ b/src/components/OracleQueryList/LoadingItem.tsx
@@ -35,7 +35,6 @@ export function LoadingItem() {
 const loadingTitle = (
   <TitleWrapper>
     <HeaderWrapper>
-      <LoadingSkeleton width={18} height={18} borderRadius="50%" />
       <TitleHeader>
         <LoadingSkeleton width={150} />
       </TitleHeader>

--- a/src/components/OracleQueryList/style.tsx
+++ b/src/components/OracleQueryList/style.tsx
@@ -4,9 +4,6 @@ import { oracleQueryHover } from "../style";
 export const TitleWrapper = styled.div``;
 
 export const HeaderWrapper = styled.div`
-  display: grid;
-  grid-template-columns: 18px auto;
-  gap: 8px;
   margin-bottom: 4px;
 `;
 

--- a/src/components/OracleQueryTable/VerifyCells.tsx
+++ b/src/components/OracleQueryTable/VerifyCells.tsx
@@ -51,6 +51,10 @@ export function VerifyCells({
             startTime={timeMilliseconds}
             endTime={livenessEndsMilliseconds}
             endedLabel={isManaged ? "Awaiting Settlement" : undefined}
+            gracePeriodMs={isManaged ? 5 * 60 * 1000 : undefined}
+            gracePeriodLabel={
+              isManaged ? "Challenge Period Extended" : undefined
+            }
           />
         </TD>
       ) : undefined}


### PR DESCRIPTION
## Summary

- For Managed OOV2 (MOOV2) proposals on the verify tab, replaces the immediate \"Awaiting Settlement\" label with a two-phase post-expiry state
- **0–5 min after expiry**: countdown freezes at \"0 m 00 s\" (red), indicating the period has ended but no decision has been made
- **5+ min after expiry**: label switches to \"Challenge Period Extended\" (red), signaling that human review may be delaying settlement

## Motivation

A backend change rolling out 2026-03-25 delays settlement for MOOV2 requests flagged for human review. The previous UI showed \"Awaiting Settlement\" instantly at T=0, implying no further delay was possible. Since there is no on-chain signal to detect which requests will be held, a 5-minute proxy window is used instead.

## Changes

- **`LivenessProgressBar`**: Added optional `gracePeriodMs` and `gracePeriodLabel` props. When provided, the component freezes at \"0 m 00 s\" during the grace window, then shows `gracePeriodLabel` after it elapses. All existing callers are unaffected (props are optional).
- **`VerifyCells`** + **`ItemDetails`**: Pass `gracePeriodMs={5 * 60 * 1000}` and `gracePeriodLabel="Challenge Period Extended"` only when `isManaged` is true.

## Adjusting the grace period in the future

If backend settlement timing changes, update `gracePeriodMs` in **two places**:

- `src/components/OracleQueryTable/VerifyCells.tsx`
- `src/components/OracleQueryList/ItemDetails.tsx`

Both must be updated together to keep the table row and mobile sidebar in sync. The value is in milliseconds — e.g. `10 * 60 * 1000` for 10 minutes.

If the threshold becomes dynamic or data-driven in the future, derive it from `livenessEndsMilliseconds` in `src/helpers/converters.ts` and pass it as a prop rather than hardcoding at the call site.

## Testing

- [ ] MOOV2 verify tab: countdown runs normally until expiry
- [ ] MOOV2 verify tab: shows \"0 m 00 s\" in red immediately after expiry
- [ ] MOOV2 verify tab: shows \"Challenge Period Extended\" in red after 5 minutes
- [ ] Regular OOV2: unaffected (still shows \"Ended\" at expiry)
- [ ] Assertions: unaffected

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)