### PR TITLE
fix: deeplinks with eventIndex not returning correct request

### DIFF
--- a/libs/src/oracle-sdk-v2/services/managedv2/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/managedv2/gql/queries.ts
@@ -189,13 +189,25 @@ export async function getSettledRequests(
 
 // --- Deeplink: lookup by transaction hash ---
 
-export async function getRequestByHash(url: string, txHash: string) {
+export async function getRequestByHash(
+  url: string,
+  txHash: string,
+  eventIndex?: number,
+) {
+  const exactMatchQueries =
+    eventIndex !== undefined
+      ? `
+      byRequestExact: optimisticPriceRequests(where: { requestHash: "${txHash}", requestLogIndex: "${eventIndex}" }, first: 1) { ${managedFields} }
+      byProposalExact: optimisticPriceRequests(where: { proposalHash: "${txHash}", proposalLogIndex: "${eventIndex}" }, first: 1) { ${managedFields} }
+      byDisputeExact: optimisticPriceRequests(where: { disputeHash: "${txHash}", disputeLogIndex: "${eventIndex}" }, first: 1) { ${managedFields} }
+      bySettlementExact: optimisticPriceRequests(where: { settlementHash: "${txHash}", settlementLogIndex: "${eventIndex}" }, first: 1) { ${managedFields} }`
+      : "";
   const query = gql`
-    query GetManagedRequestByHash {
-      byRequest: optimisticPriceRequests(where: { requestHash: "${txHash}" }, first: 5) { ${managedFields} }
-      byProposal: optimisticPriceRequests(where: { proposalHash: "${txHash}" }, first: 5) { ${managedFields} }
-      byDispute: optimisticPriceRequests(where: { disputeHash: "${txHash}" }, first: 5) { ${managedFields} }
-      bySettlement: optimisticPriceRequests(where: { settlementHash: "${txHash}" }, first: 5) { ${managedFields} }
+    query GetManagedRequestByHash {${exactMatchQueries}
+      byRequest: optimisticPriceRequests(where: { requestHash: "${txHash}" }, first: 100) { ${managedFields} }
+      byProposal: optimisticPriceRequests(where: { proposalHash: "${txHash}" }, first: 100) { ${managedFields} }
+      byDispute: optimisticPriceRequests(where: { disputeHash: "${txHash}" }, first: 100) { ${managedFields} }
+      bySettlement: optimisticPriceRequests(where: { settlementHash: "${txHash}" }, first: 100) { ${managedFields} }
     }
   `;
   const result = await request<

--- a/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts
@@ -203,14 +203,27 @@ export async function getRequestByHash(
   url: string,
   txHash: string,
   oracleType: OracleType,
+  eventIndex?: number,
 ) {
   const fields = requestFields(oracleType);
+  // When eventIndex is provided, exact (hash + logIndex) matches deterministically
+  // pinpoint the target entity even when a single tx contains many requests
+  // (a batch). The broader hash-only queries below remain so proximity scoring
+  // still works when eventIndex is missing or doesn't line up exactly.
+  const exactMatchQueries =
+    eventIndex !== undefined
+      ? `
+      byRequestExact: optimisticPriceRequests(where: { requestHash: "${txHash}", requestLogIndex: "${eventIndex}" }, first: 1) { ${fields} }
+      byProposalExact: optimisticPriceRequests(where: { proposalHash: "${txHash}", proposalLogIndex: "${eventIndex}" }, first: 1) { ${fields} }
+      byDisputeExact: optimisticPriceRequests(where: { disputeHash: "${txHash}", disputeLogIndex: "${eventIndex}" }, first: 1) { ${fields} }
+      bySettlementExact: optimisticPriceRequests(where: { settlementHash: "${txHash}", settlementLogIndex: "${eventIndex}" }, first: 1) { ${fields} }`
+      : "";
   const query = gql`
-    query GetRequestByHash {
-      byRequest: optimisticPriceRequests(where: { requestHash: "${txHash}" }, first: 5) { ${fields} }
-      byProposal: optimisticPriceRequests(where: { proposalHash: "${txHash}" }, first: 5) { ${fields} }
-      byDispute: optimisticPriceRequests(where: { disputeHash: "${txHash}" }, first: 5) { ${fields} }
-      bySettlement: optimisticPriceRequests(where: { settlementHash: "${txHash}" }, first: 5) { ${fields} }
+    query GetRequestByHash {${exactMatchQueries}
+      byRequest: optimisticPriceRequests(where: { requestHash: "${txHash}" }, first: 100) { ${fields} }
+      byProposal: optimisticPriceRequests(where: { proposalHash: "${txHash}" }, first: 100) { ${fields} }
+      byDispute: optimisticPriceRequests(where: { disputeHash: "${txHash}" }, first: 100) { ${fields} }
+      bySettlement: optimisticPriceRequests(where: { settlementHash: "${txHash}" }, first: 100) { ${fields} }
     }
   `;
   const result = await request<

--- a/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
+++ b/libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts
@@ -111,12 +111,23 @@ export async function getSettledAssertions(
 
 // --- Deeplink: lookup by transaction hash ---
 
-export async function getAssertionByHash(url: string, txHash: string) {
+export async function getAssertionByHash(
+  url: string,
+  txHash: string,
+  eventIndex?: number,
+) {
+  const exactMatchQueries =
+    eventIndex !== undefined
+      ? `
+      byAssertionExact: assertions(where: { assertionHash: "${txHash}", assertionLogIndex: "${eventIndex}" }, first: 1) { ${assertionFields} }
+      byDisputeExact: assertions(where: { disputeHash: "${txHash}", disputeLogIndex: "${eventIndex}" }, first: 1) { ${assertionFields} }
+      bySettlementExact: assertions(where: { settlementHash: "${txHash}", settlementLogIndex: "${eventIndex}" }, first: 1) { ${assertionFields} }`
+      : "";
   const query = gql`
-    query GetAssertionByHash {
-      byAssertion: assertions(where: { assertionHash: "${txHash}" }, first: 5) { ${assertionFields} }
-      byDispute: assertions(where: { disputeHash: "${txHash}" }, first: 5) { ${assertionFields} }
-      bySettlement: assertions(where: { settlementHash: "${txHash}" }, first: 5) { ${assertionFields} }
+    query GetAssertionByHash {${exactMatchQueries}
+      byAssertion: assertions(where: { assertionHash: "${txHash}" }, first: 100) { ${assertionFields} }
+      byDispute: assertions(where: { disputeHash: "${txHash}" }, first: 100) { ${assertionFields} }
+      bySettlement: assertions(where: { settlementHash: "${txHash}" }, first: 100) { ${assertionFields} }
     }
   `;
   const result = await request<Record<string, OOV3GraphEntity[]>>(url, query);

--- a/src/pages/api/resolve-deeplink/_gql.ts
+++ b/src/pages/api/resolve-deeplink/_gql.ts
@@ -39,7 +39,7 @@ export async function searchByHash(
     try {
       if (isV3(cfg.type)) {
         const entities = await fetchWithUrlFallback(cfg.urls, (url) =>
-          getAssertionByHash(url, txHash),
+          getAssertionByHash(url, txHash, eventIndex),
         );
         for (const entity of entities) {
           const score = scoreAssertionEntity(entity, txHash, eventIndex);
@@ -49,7 +49,7 @@ export async function searchByHash(
         }
       } else if (isManaged(cfg.type)) {
         const entities = await fetchWithUrlFallback(cfg.urls, (url) =>
-          getManagedRequestByHash(url, txHash),
+          getManagedRequestByHash(url, txHash, eventIndex),
         );
         for (const entity of entities) {
           const score = scoreRequestEntity(entity, txHash, eventIndex);
@@ -59,7 +59,7 @@ export async function searchByHash(
         }
       } else {
         const entities = await fetchWithUrlFallback(cfg.urls, (url) =>
-          getOOV1RequestByHash(url, txHash, cfg.type),
+          getOOV1RequestByHash(url, txHash, cfg.type, eventIndex),
         );
         for (const entity of entities) {
           const score = scoreRequestEntity(entity, txHash, eventIndex);


### PR DESCRIPTION
closes FE-535
# Fix deeplink resolving to wrong entity in batch transactions

## Summary

Deeplinks like `?transactionHash=0x...&eventIndex=474` could resolve to the wrong request when the transaction contained multiple lifecycle events for different markets (e.g. a batch-propose tx covering 20 proposals). The endpoint would return whichever entity happened to be in the truncated subgraph result, ignoring the `eventIndex` disambiguator.

## Root cause

The deeplink GQL helpers (`getRequestByHash`, `getManagedRequestByHash`, `getAssertionByHash`) queried each hash field with `first: 5`. For batch transactions with more than 5 matching entities, the target entity could be excluded from the result set entirely, so `eventIndex`-based scoring had nothing to disambiguate against.

Observed in production with `txHash=0xb201...` (`eventIndex=474`): the tx contained 20 batched proposals, so `byProposal` returned 5 of 20 — none of which were the intended target.

## Fix

When `eventIndex` is provided, add aliased exact-match queries that filter on `(hash, logIndex)` together with `first: 1`. These deterministically pin the target row regardless of batch size. The fallback hash-only queries are bumped from `first: 5` to `first: 100` so proximity scoring still works when `eventIndex` is missing or has minor drift (e.g. URLs constructed by external apps).

Files changed:

- `libs/src/oracle-sdk-v2/services/oraclev1/gql/queries.ts` — `getRequestByHash` accepts `eventIndex`, adds 4 exact-match aliases
- `libs/src/oracle-sdk-v2/services/managedv2/gql/queries.ts` — same for managed v2
- `libs/src/oracle-sdk-v2/services/oraclev3/gql/queries.ts` — same for v3 (3 aliases)
- `src/pages/api/resolve-deeplink/_gql.ts` — threads `eventIndex` through to all three helpers

## Why current-state routing still works

External apps generating these URLs don't know whether the `txHash` belongs to a request, proposal, dispute, or settlement event. That's fine — the subgraph stores all four hashes on the same row, so we always recover the same entity regardless of which event the URL was built from. Page routing (`/`, `/propose`, `/settled`) is computed from the entity's current `state`, not from the URL.

## Test plan

- [x] Visit `?transactionHash=0xb201442bab8551221ae0e9df9fdbaa4de3ba651adf9b6973ab4ef4d3cff45876&eventIndex=474` and confirm the panel opens for "Will Player G win the 2026 men's singles tournament at the Miami Open?"
- [x] Confirm a deeplink generated from a non-batched request still resolves correctly
- [x] Confirm a deeplink with only `transactionHash` (no `eventIndex`) still resolves
