### PR TITLE
fix(polymarket): query bulletin updates from remapped initializer owners

### DIFF
--- a/src/components/Panel/PolymarketTextData.tsx
+++ b/src/components/Panel/PolymarketTextData.tsx
@@ -1,10 +1,13 @@
 import { SectionSubTitle, Text } from "./style";
 import { AdditionalTextData } from "./AdditionalTextData";
-import { useContractRead, type Address } from "wagmi";
+import { useContractReads, type Address } from "wagmi";
 import { polymarketBulletinAbi } from "@shared/constants/abi";
 import { utils } from "ethers";
 import { isWagmiAddress, toUtcTimeFormatted } from "@/helpers";
-import { getInitializerAddress } from "@/helpers/queryParsing";
+import {
+  getBulletinOwners,
+  getInitializerAddress,
+} from "@/helpers/queryParsing";
 
 interface Props {
   description: string | undefined;
@@ -29,16 +32,19 @@ export function useGetUpdates(props: {
 }) {
   const { queryTextHex, description, address } = props;
   const questionId = queryTextHex ? utils.keccak256(queryTextHex) : undefined;
-  const ownerAddress = getInitializerAddress(description);
+  const initializer = getInitializerAddress(description);
+  const owners = initializer ? getBulletinOwners(initializer) : [];
 
-  return useContractRead({
-    address,
-    abi: polymarketBulletinAbi,
-    functionName: "getUpdates",
-    // bulletin contractr on polygon
-    chainId: 137,
-    args: [questionId as Address, ownerAddress!],
-    enabled: !!address && !!questionId && !!ownerAddress,
+  return useContractReads({
+    contracts: owners.map((owner) => ({
+      address,
+      abi: polymarketBulletinAbi,
+      functionName: "getUpdates" as const,
+      // bulletin contract on polygon
+      chainId: 137,
+      args: [questionId as Address, owner],
+    })),
+    enabled: !!address && !!questionId && owners.length > 0,
   });
 }
 
@@ -51,14 +57,17 @@ export function PolymarketTextData(props: Props) {
     queryTextHex: props.queryTextHex,
     description: props.description,
   });
+  const mergedUpdates = bulletinUpdates?.data
+    ?.flatMap((result) => (result.status === "success" ? result.result : []))
+    .sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
   return (
     <>
-      {bulletinUpdates?.data?.length ? (
+      {mergedUpdates?.length ? (
         <>
           <SectionSubTitle>Polymarket Bulletin Board</SectionSubTitle>
-          {bulletinUpdates.data.map((data) => {
+          {mergedUpdates.map((data, index) => {
             return (
-              <Text key={data.timestamp.toString()}>
+              <Text key={`${data.timestamp.toString()}-${index}`}>
                 {toUtcTimeFormatted(data.timestamp.toString())}:{" "}
                 {utils.toUtf8String(data.update)}
               </Text>

--- a/src/helpers/queryParsing.test.ts
+++ b/src/helpers/queryParsing.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest";
-import { getQueryMetaData } from "./queryParsing";
+import { getBulletinOwners, getQueryMetaData } from "./queryParsing";
+import type { Address } from "wagmi";
 
 describe("getQueryMetaData - YES_OR_NO_QUERY and Polymarket", () => {
   const polymarketRequester = "0xcb1822859cef82cd2eb4e6276c7916e692995130"; // Polymarket Binary Adapter Address
@@ -120,5 +121,24 @@ describe("getQueryMetaData - YES_OR_NO_QUERY and Polymarket", () => {
     expect(result.description).toBe(
       "q:Did the Dallas Mavericks beat the Miami Heat January 6th, 2022?, p1:0, p2:1, p3:0.5, earlyExpiration:1",
     );
+  });
+});
+
+describe("getBulletinOwners", () => {
+  const deprecated = "0x91430cad2d3975766499717fa0d66a78d814e5c5" as Address;
+  const replacement = "0xf43d55f3a8b7484ed4b6931f93cb6f9ef5dd369d" as Address;
+
+  test("returns the deprecated initializer alongside the replacement owner", () => {
+    expect(getBulletinOwners(deprecated)).toEqual([deprecated, replacement]);
+  });
+
+  test("looks up remaps case-insensitively while preserving input casing", () => {
+    const upper = deprecated.toUpperCase() as Address;
+    expect(getBulletinOwners(upper)).toEqual([upper, replacement]);
+  });
+
+  test("returns just the input when no remap is configured", () => {
+    const other = "0x1111111111111111111111111111111111111111" as Address;
+    expect(getBulletinOwners(other)).toEqual([other]);
   });
 });

--- a/src/helpers/queryParsing.ts
+++ b/src/helpers/queryParsing.ts
@@ -37,6 +37,22 @@ export function getInitializerAddress(
   }
 }
 
+// Additional bulletin-board owners to query alongside a request's initializer.
+// When an initializer EOA is deprecated, clarifications continue to be posted
+// under a replacement EOA against the same questionId. The replaced owner is
+// kept in the query list so clarifications posted before the swap remain
+// visible.
+const bulletinOwnerRemaps: Record<string, Address[]> = {
+  "0x91430cad2d3975766499717fa0d66a78d814e5c5": [
+    "0xf43d55f3a8b7484ed4b6931f93cb6f9ef5dd369d",
+  ],
+};
+
+export function getBulletinOwners(initializer: Address): Address[] {
+  const extras = bulletinOwnerRemaps[initializer.toLowerCase()] ?? [];
+  return [initializer, ...extras];
+}
+
 // Define MetaData type here for this file
 export type MetaData = {
   title: string;


### PR DESCRIPTION
## Summary

The initializer EOA `0x91430cad...e5c5` is no longer in use. Clarifications for its existing requests are now posted by `0xf43d55f3...369d` under the same `questionId`. This switches the bulletin lookup from `useContractRead` (single) to `useContractReads` (batch) so both the initializer named in ancillary data and any remapped successor are queried in one call. Results are merged across owners and sorted by timestamp ascending — prior clarifications stay visible alongside new ones.

Mirrors UMAprotocol/voter-dapp-v2#454.

- `src/helpers/queryParsing.ts` — adds `bulletinOwnerRemaps` table and `getBulletinOwners()` helper.
- `src/components/Panel/PolymarketTextData.tsx` — `useGetUpdates` now uses `useContractReads`; consumer flattens, drops failed reads, sorts by timestamp.
- `src/helpers/queryParsing.test.ts` — unit tests for the remap (mapped, case-insensitive, passthrough).

## Notes

- `questionId` derivation is unchanged (`keccak256(queryTextHex)` directly, no sanitize step). voter-dapp-v2 strips appended `ooRequester` / `childRequester` / `childChainId` before hashing — flagging in case this is a latent bug here too, but it's out of scope.
- A companion PR adds the new EOA `0xF43d55F3…369D` to `PolymarketProject.initializers` for project tagging.

## Test plan

- [x] `yarn test` — all tests pass
- [x] `yarn prettier --check` on changed files
- [ ] Verify in dApp that a request whose ancillary data names `0x91430cad...e5c5` displays clarifications from both `(questionId, 0x91430cad...)` (prior) and `(questionId, 0xf43d55f3...)` (new), sorted by timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)