### PR TITLE
chore(polymarket): register new initializer 0xF43d55F3...369D

### DIFF
--- a/src/projects/polymarket.ts
+++ b/src/projects/polymarket.ts
@@ -21,6 +21,7 @@ export class PolymarketProject extends Project<"Polymarket"> {
         "0x084EA0bAC17aD8a23A84F596b4adcA432aa118A3",
         "0x9E2ad3FB89B6357b601932B673f77B371ff91871",
         "0x6e0c80c90ea6c15917308f820eac91ce2724b5b5",
+        "0xF43d55F3A8B7484Ed4B6931f93CB6F9eF5Dd369D",
       ],
       requesters: [
         "0xcb1822859cef82cd2eb4e6276c7916e692995130", // Polymarket Binary Adapter Address


### PR DESCRIPTION
## Summary

Adds `0xF43d55F3A8B7484Ed4B6931f93CB6F9eF5Dd369D` to `PolymarketProject.initializers` so requests it initializes are recognized as Polymarket in the UI.


## Test plan

- [x] `yarn test` passes
- [x] `yarn prettier --check` clean
- [ ] Verify in dApp that a request initialized by `0xF43d55F3…369D` is tagged "Polymarket"

🤖 Generated with [Claude Code](https://claude.com/claude-code)